### PR TITLE
Make daily build to use latest dependencies

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -36,6 +36,7 @@ jobs:
           # Build and Generate Coverage Report With Ballerina
           for folder in "${BALLERINA_PROJECTS[@]}"; do
             pushd "$folder"
+            rm -f Dependencies.toml
             bal build
             bal test --test-report --code-coverage --coverage-format=xml
             popd


### PR DESCRIPTION
## Purpose
> daily build is use to verify the stability of a package/service with latest dependencies, since the daily build runs with already committed dependencies.toml file, it's difficult to determine the build status.

## Approach
> remove Dependencies.toml file in the daily build pipeline, before executing the build command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized daily build workflow with enhanced pre-build cleanup procedures to ensure consistent build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->