### PR TITLE
Fix reference-type parameter handling in search

### DIFF
--- a/miscellaneous/fhir-server/modules/mappers/read_mapper.bal
+++ b/miscellaneous/fhir-server/modules/mappers/read_mapper.bal
@@ -133,27 +133,35 @@ public class ReadMapper {
                 if isOldFormatReference {
                     refValue = paramName;
                     string[] parts = regexp:split(re `/`, refValue);
-                    if parts.length() == 2 {
+                    // Catch "Patient/", "Patient/123/123", "/123"
+                    if parts.length() == 2 && parts[0] != "" && parts[1] != "" {
                         targetType = parts[0];
                         targetId = parts[1];
+                    } else {
+                        return error(string `Invalid reference format: '${paramName}'`);
                     }
+
                 }
                 // Case 2: patient=Patient/123 (proper FHIR search format)
                 else if paramValue.includes("/") && !paramValue.includes("://") {
                     refValue = paramValue;
                     string[] parts = regexp:split(re `/`, refValue);
-                    if parts.length() == 2 {
+
+                    // 
+                    if parts.length() == 2 && parts[0] != "" && parts[1] != "" {
                         targetType = parts[0];
                         targetId = parts[1];
+                    } else {
+                        return error(string `Invalid reference format for parameter '${paramName}': '${paramValue}'`);
                     }
                 }
                 // Case 3: patient=123 (just the resource ID without type prefix) - NOT SUPPORTED YET
                 else if !paramValue.includes("://") {
-                    return error(string `Reference search parameter '${paramName}' must include resource type (e.g., '${paramName}=Patient/123', not '${paramName}=${paramValue}')`);
+                    return error(string `Invalid reference: search parameter '${paramName}' must include resource type (e.g., '${paramName}=Patient/123', not '${paramName}=${paramValue}')`);
                 }
                 // Case 4: patient=http://example.com/fhir/Patient/123 (absolute URL) - NOT SUPPORTED YET
                 else if paramValue.includes("://") {
-                    return error(string `Absolute URL references are not supported. Use relative references instead (e.g., '${paramName}=Patient/123')`);
+                    return error(string `Invalid reference: absolute URL '${paramValue}' is not supported for parameter '${paramName}'. Use relative references instead (e.g., '${paramName}=Patient/123')`);
                 } else {
                     return error(string `Invalid reference format for parameter '${paramName}': '${paramValue}'`);
                 }
@@ -169,7 +177,7 @@ public class ReadMapper {
                     if refInfo.validTargetTypes != "any" {
                         string[] allowedTypes = <string[]>refInfo.validTargetTypes;
                         if allowedTypes.indexOf(targetType) is () {
-                            return error(string `Reference search parameter '${paramName}' does not support target type '${targetType}'`);
+                            return error(string `Invalid reference: search parameter '${paramName}' does not support target type '${targetType}' (value: '${paramValue}').`);
                         }
                     }
 

--- a/miscellaneous/fhir-server/modules/mappers/read_mapper.bal
+++ b/miscellaneous/fhir-server/modules/mappers/read_mapper.bal
@@ -86,7 +86,8 @@ public class ReadMapper {
             }
 
             // Check if this is a custom extension parameter
-            boolean isCustom = check self.isCustomSearchParam(jdbcClient, resourceType, paramName);
+            var paramDef = check self.getSearchParamDef(jdbcClient, resourceType, paramName);
+            boolean isCustom = paramDef?.isCustom == true;
             if isCustom {
                 customParams[paramName] = paramValues;
             } else {
@@ -121,7 +122,8 @@ public class ReadMapper {
             // Need to check for old format where paramName itself is like "Patient/123" — treat as reference directly
             boolean isOldFormatReference = paramName.includes("/") && !paramName.includes("://");
 
-            boolean isReferenceParam = isOldFormatReference || check self.isReferenceSearchParam(jdbcClient, resourceType, paramName);
+            var paramDef = check self.getSearchParamDef(jdbcClient, resourceType, paramName);
+            boolean isReferenceParam = isOldFormatReference || paramDef?.paramType == "reference";
 
             if isReferenceParam {
                 hasReferenceParams = true;
@@ -147,7 +149,6 @@ public class ReadMapper {
                     refValue = paramValue;
                     string[] parts = regexp:split(re `/`, refValue);
 
-                    // 
                     if parts.length() == 2 && parts[0] != "" && parts[1] != "" {
                         targetType = parts[0];
                         targetId = parts[1];
@@ -315,7 +316,8 @@ public class ReadMapper {
 
             // Skip reference parameters — already processed in the reference loop above
             boolean isTokenParam = paramValue.includes("|");
-            boolean isRefParam = check self.isReferenceSearchParam(jdbcClient, resourceType, paramName);
+            var paramDef = check self.getSearchParamDef(jdbcClient, resourceType, paramName);
+            boolean isRefParam = paramDef?.paramType == "reference";
 
             if isRefParam && !isTokenParam {
                 continue;
@@ -1181,26 +1183,6 @@ public class ReadMapper {
         return revIncludedEntries;
     }
 
-    // Check if a search parameter is a reference parameter
-    private isolated function isReferenceSearchParam(jdbc:Client jdbcClient, string resourceType, string paramName) returns boolean|error {
-        sql:ParameterizedQuery query = `
-            SELECT COUNT(*) as count
-            FROM "SEARCH_PARAM_RES_EXPRESSIONS" 
-            WHERE "RESOURCE_NAME" = ${resourceType}
-            AND "SEARCH_PARAM_NAME" = ${paramName}
-            AND "SEARCH_PARAM_TYPE" = 'reference'
-        `;
-
-        stream<record {int count;}, sql:Error?> resultStream = jdbcClient->query(query);
-        record {|record {int count;} value;|}? nextRecord = check resultStream.next();
-        check resultStream.close();
-
-        if nextRecord is record {|record {int count;} value;|} {
-            return nextRecord.value.count > 0;
-        }
-
-        return false;
-    }
 
     // Parse "resolve() is X" from a expression in SEARCH_PARAM_RES_EXPRESSIONS table and return X, or () if not present.
     // Example: "Condition.subject.where(resolve() is Patient)" → "Patient"
@@ -1266,25 +1248,27 @@ public class ReadMapper {
         return {sourceExpressions, validTargetTypes: validTargetTypes.length() > 0 ? validTargetTypes : "any"};
     }
 
-    // Check if a search parameter is a custom extension parameter
-    private isolated function isCustomSearchParam(jdbc:Client jdbcClient, string resourceType, string paramName) returns boolean|error {
+    // Fetch the registered definition of a search parameter from SEARCH_PARAM_RES_EXPRESSIONS.
+    // Returns () when the parameter is not registered.
+    private isolated function getSearchParamDef(jdbc:Client jdbcClient, string resourceType, string paramName)
+            returns record {|string paramType; boolean isCustom;|}?|error {
         sql:ParameterizedQuery query = `
-            SELECT COUNT(*) as count
-            FROM "SEARCH_PARAM_RES_EXPRESSIONS" 
+            SELECT "SEARCH_PARAM_TYPE" AS paramType, "IS_CUSTOM" AS isCustom
+            FROM "SEARCH_PARAM_RES_EXPRESSIONS"
             WHERE "RESOURCE_NAME" = ${resourceType}
-            AND "SEARCH_PARAM_NAME" = ${paramName}
-            AND "IS_CUSTOM" = ${true}
+              AND "SEARCH_PARAM_NAME" = ${paramName}
+            LIMIT 1
         `;
 
-        stream<record {int count;}, sql:Error?> resultStream = jdbcClient->query(query);
-        record {|record {int count;} value;|}|sql:Error? nextRecord = resultStream.next();
+        stream<record {|string paramType; boolean isCustom;|}, sql:Error?> resultStream = jdbcClient->query(query);
+        record {|record {|string paramType; boolean isCustom;|} value;|}? nextRecord = check resultStream.next();
         check resultStream.close();
 
-        if nextRecord is record {|record {int count;} value;|} {
-            return nextRecord.value.count > 0;
+        if nextRecord is record {|record {|string paramType; boolean isCustom;|} value;|} {
+            return nextRecord.value;
         }
 
-        return false;
+        return ();
     }
 
     // Create an empty FHIR Bundle

--- a/miscellaneous/fhir-server/modules/mappers/read_mapper.bal
+++ b/miscellaneous/fhir-server/modules/mappers/read_mapper.bal
@@ -65,7 +65,6 @@ public class ReadMapper {
     }
 
     // Search resources with filters - basic implementation
-    // Search resources with filters - basic implementation
     public isolated function searchResources(jdbc:Client? jdbcClient, string resourceType, map<string[]> queryParams, r4:PaginationContext? paginationContext = ()) returns json|error {
         if jdbcClient is () {
             return error("JDBC client is not initialized");
@@ -119,34 +118,69 @@ public class ReadMapper {
 
             string paramValue = paramValues[0];
 
-            // Check if this is a reference parameter
-            // Either: 1) paramName contains "/" (e.g., "Patient/123" as key)
-            //     or: 2) paramValue contains "/" (e.g., patient=Patient/123)
-            boolean isReferenceParam = paramName.includes("/") || paramValue.includes("/");
+            // Need to check for old format where paramName itself is like "Patient/123" — treat as reference directly
+            boolean isOldFormatReference = paramName.includes("/") && !paramName.includes("://");
+
+            boolean isReferenceParam = isOldFormatReference || check self.isReferenceSearchParam(jdbcClient, resourceType, paramName);
 
             if isReferenceParam {
                 hasReferenceParams = true;
-                string refValue = "";
+                string refValue = "";    // eg: "Patient/123"
+                string targetType = "";  // eg: "Patient"
+                string targetId = "";    // eg: "123"
 
                 // Case 1: paramName is "Patient/123" (old format)
-                if paramName.includes("/") {
+                if isOldFormatReference {
                     refValue = paramName;
+                    string[] parts = regexp:split(re `/`, refValue);
+                    if parts.length() == 2 {
+                        targetType = parts[0];
+                        targetId = parts[1];
+                    }
                 }
                 // Case 2: patient=Patient/123 (proper FHIR search format)
-                else {
+                else if paramValue.includes("/") && !paramValue.includes("://") {
                     refValue = paramValue;
+                    string[] parts = regexp:split(re `/`, refValue);
+                    if parts.length() == 2 {
+                        targetType = parts[0];
+                        targetId = parts[1];
+                    }
+                }
+                // Case 3: patient=123 (just the resource ID without type prefix) - NOT SUPPORTED YET
+                else if !paramValue.includes("://") {
+                    return error(string `Reference search parameter '${paramName}' must include resource type (e.g., '${paramName}=Patient/123', not '${paramName}=${paramValue}')`);
+                }
+                // Case 4: patient=http://example.com/fhir/Patient/123 (absolute URL) - NOT SUPPORTED YET
+                else if paramValue.includes("://") {
+                    return error(string `Absolute URL references are not supported. Use relative references instead (e.g., '${paramName}=Patient/123')`);
+                } else {
+                    return error(string `Invalid reference format for parameter '${paramName}': '${paramValue}'`);
                 }
 
-                string[] parts = regexp:split(re `/`, refValue);
-                if parts.length() == 2 {
-                    string targetType = parts[0];
-                    string targetId = parts[1];
+                if targetType != "" && targetId != "" {
 
-                    // Build query without SOURCE_EXPRESSION filter
-                    // The TARGET_RESOURCE_TYPE already provides the specificity we need
-                    // (e.g., searching patient=Patient/123 matches any reference to that Patient,
-                    //  whether stored as "actor", "patient", "subject", etc.)
-                    string refQuery = string `SELECT DISTINCT "SOURCE_RESOURCE_ID" FROM "REFERENCES" WHERE "SOURCE_RESOURCE_TYPE" = '${utils:escapeSql(resourceType)}' AND "TARGET_RESOURCE_TYPE" = '${utils:escapeSql(targetType)}' AND "TARGET_RESOURCE_ID" = '${utils:escapeSql(targetId)}'`;
+                    record {|string[] sourceExpressions; string|string[] validTargetTypes;|} refInfo = check self.getSourceExpressionsAndTargetTypes(jdbcClient, resourceType, paramName);
+
+                    // "any" means no resolve() is constraint in the expression 
+                    // The target type is still implicitly filtered in the REFERENCES query via TARGET_RESOURCE_TYPE,
+                    // so subject=Practitioner/123 will return 0 results **if no such data exists** rather than an error.
+                    // TODO: By using SearchParameter.target we could verify this explicitly. For that need to add target types to the SEARCH_PARAM_RES_EXPRESSIONS table
+                    if refInfo.validTargetTypes != "any" {
+                        string[] allowedTypes = <string[]>refInfo.validTargetTypes;
+                        if allowedTypes.indexOf(targetType) is () {
+                            return error(string `Reference search parameter '${paramName}' does not support target type '${targetType}'`);
+                        }
+                    }
+
+                    // Filter by SOURCE_EXPRESSION if we resolved the underlying element name(s)
+                    string sourceExprFilter = "";
+                    if refInfo.sourceExpressions.length() > 0 {
+                        string fieldList = string:'join(", ", ...from var f in refInfo.sourceExpressions select string `'${utils:escapeSql(f)}'`);
+                        sourceExprFilter = string ` AND "SOURCE_EXPRESSION" IN (${fieldList})`;
+                    }
+
+                    string refQuery = string `SELECT DISTINCT "SOURCE_RESOURCE_ID" FROM "REFERENCES" WHERE "SOURCE_RESOURCE_TYPE" = '${utils:escapeSql(resourceType)}'${sourceExprFilter} AND "TARGET_RESOURCE_TYPE" = '${utils:escapeSql(targetType)}' AND "TARGET_RESOURCE_ID" = '${utils:escapeSql(targetId)}'`;
 
                     sql:ParameterizedQuery query = new utils:RawSQLQuery(refQuery);
 
@@ -221,8 +255,10 @@ public class ReadMapper {
         }
 
         if finalResourceIds is string[] && finalResourceIds.length() > 0 {
-            string idList = string:'join("', '", ...finalResourceIds);
-            whereClause = string ` WHERE "${primaryKey}" IN ('${idList}')`;
+            string[] sanitizedFinalResourceIds = from var id in finalResourceIds
+                select utils:escapeSql(id);
+            string idList = string:'join("', '", ...sanitizedFinalResourceIds);
+            whereClause = string ` WHERE "${utils:escapeSql(primaryKey)}" IN ('${idList}')`;
         } else if finalResourceIds is string[] && finalResourceIds.length() == 0 {
             // No matches from filtering, return empty bundle
             return self.createEmptyBundle();
@@ -233,9 +269,9 @@ public class ReadMapper {
             string[] idValues = queryParams.get("_id");
             if idValues.length() > 0 {
                 if whereClause == "" {
-                    whereClause = string ` WHERE "${primaryKey}" = '${idValues[0]}'`;
+                    whereClause = string ` WHERE "${utils:escapeSql(primaryKey)}" = '${utils:escapeSql(idValues[0])}'`;
                 } else {
-                    whereClause = whereClause + string ` AND "${primaryKey}" = '${idValues[0]}'`;
+                    whereClause = whereClause + string ` AND "${utils:escapeSql(primaryKey)}" = '${utils:escapeSql(idValues[0])}'`;
                 }
             }
         }
@@ -269,14 +305,11 @@ public class ReadMapper {
                 continue;
             }
 
-            // Skip reference parameters (already processed above)
-            // Reference params have "/" BUT not token params (which use | for system|code)
-            // Token example: identifier=http://hospital.org|12345 (has "/" but is NOT a reference)
-            // Reference example: patient=Patient/123 (has "/" and IS a reference)
+            // Skip reference parameters — already processed in the reference loop above
             boolean isTokenParam = paramValue.includes("|");
-            boolean hasSlash = paramName.includes("/") || paramValue.includes("/");
+            boolean isRefParam = check self.isReferenceSearchParam(jdbcClient, resourceType, paramName);
 
-            if hasSlash && !isTokenParam {
+            if isRefParam && !isTokenParam {
                 continue;
             }
 
@@ -1138,6 +1171,91 @@ public class ReadMapper {
         }
 
         return revIncludedEntries;
+    }
+
+    // Check if a search parameter is a reference parameter
+    private isolated function isReferenceSearchParam(jdbc:Client jdbcClient, string resourceType, string paramName) returns boolean|error {
+        sql:ParameterizedQuery query = `
+            SELECT COUNT(*) as count
+            FROM "SEARCH_PARAM_RES_EXPRESSIONS" 
+            WHERE "RESOURCE_NAME" = ${resourceType}
+            AND "SEARCH_PARAM_NAME" = ${paramName}
+            AND "SEARCH_PARAM_TYPE" = 'reference'
+        `;
+
+        stream<record {int count;}, sql:Error?> resultStream = jdbcClient->query(query);
+        record {|record {int count;} value;|}? nextRecord = check resultStream.next();
+        check resultStream.close();
+
+        if nextRecord is record {|record {int count;} value;|} {
+            return nextRecord.value.count > 0;
+        }
+
+        return false;
+    }
+
+    // Parse "resolve() is X" from a expression in SEARCH_PARAM_RES_EXPRESSIONS table and return X, or () if not present.
+    // Example: "Condition.subject.where(resolve() is Patient)" → "Patient"
+    private isolated function extractTargetTypeFromExpression(string expression) returns string? {
+        string marker = "resolve() is ";
+        int? markerIdx = expression.indexOf(marker);
+        if markerIdx is int {
+            string afterMarker = expression.substring(markerIdx + marker.length());
+            regexp:Span? typeNameEnd = regexp:find(re `[^A-Za-z]`, afterMarker);
+            string typeName = typeNameEnd is regexp:Span ? afterMarker.substring(0, typeNameEnd.startIndex) : afterMarker;
+            if typeName.length() > 0 {
+                return typeName;
+            }
+        }
+        return ();
+    }
+
+    // Extract the reference field name from a FHIRPath expression — the last path segment before ".where(" or end.
+    // Example: "Condition.subject.where(resolve() is Patient)" → "subject"
+    // Example: "Patient.generalPractitioner" → "generalPractitioner"
+    private isolated function extractReferenceFieldFromExpression(string expression) returns string? {
+        int? whereIdx = expression.indexOf(".where(");
+        string pathPart = whereIdx is int ? expression.substring(0, whereIdx) : expression;
+        int? lastDot = pathPart.lastIndexOf(".");
+        string 'field = lastDot is int ? pathPart.substring(lastDot + 1) : pathPart;
+        return 'field.length() > 0 ? 'field : ();
+    }
+
+    // Given a reference search param name, extracts from SEARCH_PARAM_RES_EXPRESSIONS:
+    //   sourceExpressions — FHIRPath element names (e.g. "subject") that this param maps to.
+    //                       Multiple search params (e.g. "patient", "subject") can map to the same element.
+    //   validTargetTypes  — allowed target resource types from "resolve() is X", or "any" if unconstrained.
+    //                       "any" means the expression has no type restriction — the REFERENCES query
+    //                       will naturally return 0 results if no matching data exists.
+    //
+    // Example: "patient" on Condition → "Condition.subject.where(resolve() is Patient)"
+    //          → {sourceExpressions: ["subject"], validTargetTypes: ["Patient"]}
+    // Example: "subject" on Condition → "Condition.subject"
+    //          → {sourceExpressions: ["subject"], validTargetTypes: "any"}
+    private isolated function getSourceExpressionsAndTargetTypes(jdbc:Client jdbcClient, string resourceType, string paramName)
+            returns record {|string[] sourceExpressions; string|string[] validTargetTypes;|}|error {
+        stream<record {|string EXPRESSION;|}, sql:Error?> spStream = jdbcClient->query(
+            `SELECT "EXPRESSION" FROM "SEARCH_PARAM_RES_EXPRESSIONS"
+             WHERE "RESOURCE_NAME" = ${resourceType}
+               AND "SEARCH_PARAM_NAME" = ${paramName}
+               AND "SEARCH_PARAM_TYPE" = 'reference'`
+        );
+        record {|string EXPRESSION;|}[] rows = check from var r in spStream select r;
+
+        string[] sourceExpressions = [];
+        string[] validTargetTypes = [];
+        foreach var row in rows {
+            string? sourceExpr = self.extractReferenceFieldFromExpression(row.EXPRESSION);
+            if sourceExpr is string && sourceExpressions.indexOf(sourceExpr) is () {
+                sourceExpressions.push(sourceExpr);
+            }
+            string? targetType = self.extractTargetTypeFromExpression(row.EXPRESSION);
+            if targetType is string && validTargetTypes.indexOf(targetType) is () {
+                validTargetTypes.push(targetType);
+            }
+        }
+        // "any" means no resolve() is constraint was found — all target types are permitted
+        return {sourceExpressions, validTargetTypes: validTargetTypes.length() > 0 ? validTargetTypes : "any"};
     }
 
     // Check if a search parameter is a custom extension parameter

--- a/miscellaneous/fhir-server/modules/mappers/read_mapper.bal
+++ b/miscellaneous/fhir-server/modules/mappers/read_mapper.bal
@@ -74,22 +74,29 @@ public class ReadMapper {
         string tableName = utils:getTableName(resourceType);
         string[] tableColumns = check mapperUtils:getTableColumns(jdbcClient, tableName);
 
-        // First, check if there are any custom extension search parameters
+        // Classify parameters into three types
         map<string[]> customParams = {};
+        map<string[]> refParams = {};
         map<string[]> standardParams = {};
 
         foreach var [paramName, paramValues] in queryParams.entries() {
             // Skip control parameters
-            if paramName.startsWith("_") || paramName.includes("/") {
+            if paramName.startsWith("_") {
                 standardParams[paramName] = paramValues;
                 continue;
             }
 
-            // Check if this is a custom extension parameter
+            // Old-format reference: paramName itself is "ResourceType/id"
+            if paramName.includes("/") && !paramName.includes("://") {
+                refParams[paramName] = paramValues;
+                continue;
+            }
+
             var paramDef = check self.getSearchParamDef(jdbcClient, resourceType, paramName);
-            boolean isCustom = paramDef?.isCustom == true;
-            if isCustom {
+            if paramDef?.isCustom == true {
                 customParams[paramName] = paramValues;
+            } else if paramDef?.paramType == "reference" {
+                refParams[paramName] = paramValues;
             } else {
                 standardParams[paramName] = paramValues;
             }
@@ -108,68 +115,54 @@ public class ReadMapper {
 
         string primaryKey = utils:getPrimaryKeyColumn(resourceType);
 
-        // Check for reference parameters and query the REFERENCES table
+        // Process reference parameters and query the REFERENCES table
         string[]? matchingResourceIds = ();
-        boolean hasReferenceParams = false;
+        boolean hasReferenceParams = refParams.length() > 0;
 
-        foreach var [paramName, paramValues] in queryParams.entries() {
+        foreach var [paramName, paramValues] in refParams.entries() {
             if paramValues.length() == 0 {
                 continue;
             }
-
             string paramValue = paramValues[0];
+            string targetType = "";  // eg: "Patient"
+            string targetId = "";    // eg: "123"
 
-            // Need to check for old format where paramName itself is like "Patient/123" — treat as reference directly
-            boolean isOldFormatReference = paramName.includes("/") && !paramName.includes("://");
-
-            var paramDef = check self.getSearchParamDef(jdbcClient, resourceType, paramName);
-            boolean isReferenceParam = isOldFormatReference || paramDef?.paramType == "reference";
-
-            if isReferenceParam {
-                hasReferenceParams = true;
-                string refValue = "";    // eg: "Patient/123"
-                string targetType = "";  // eg: "Patient"
-                string targetId = "";    // eg: "123"
-
-                // Case 1: paramName is "Patient/123" (old format)
-                if isOldFormatReference {
-                    refValue = paramName;
-                    string[] parts = regexp:split(re `/`, refValue);
-                    // Catch "Patient/", "Patient/123/123", "/123"
-                    if parts.length() == 2 && parts[0] != "" && parts[1] != "" {
-                        targetType = parts[0];
-                        targetId = parts[1];
-                    } else {
-                        return error(string `Invalid reference format: '${paramName}'`);
-                    }
-
+            // Case 1: paramName is "Patient/123" (old format)
+            if paramName.includes("/") && !paramName.includes("://") {
+                string[] parts = regexp:split(re `/`, paramName);
+                // Catch "Patient/", "Patient/123/123", "/123"
+                if parts.length() == 2 && parts[0] != "" && parts[1] != "" {
+                    targetType = parts[0];
+                    targetId = parts[1];
+                } else {
+                    return error(string `Invalid reference format: '${paramName}'`);
                 }
-                // Case 2: patient=Patient/123 (proper FHIR search format)
-                else if paramValue.includes("/") && !paramValue.includes("://") {
-                    refValue = paramValue;
-                    string[] parts = regexp:split(re `/`, refValue);
+            }
+            // Case 2: patient=Patient/123 (proper FHIR search format)
+            else if paramValue.includes("/") && !paramValue.includes("://") {
+                string[] parts = regexp:split(re `/`, paramValue);
 
-                    if parts.length() == 2 && parts[0] != "" && parts[1] != "" {
-                        targetType = parts[0];
-                        targetId = parts[1];
-                    } else {
-                        return error(string `Invalid reference format for parameter '${paramName}': '${paramValue}'`);
-                    }
-                }
-                // Case 3: patient=123 (just the resource ID without type prefix) - NOT SUPPORTED YET
-                else if !paramValue.includes("://") {
-                    return error(string `Invalid reference: search parameter '${paramName}' must include resource type (e.g., '${paramName}=Patient/123', not '${paramName}=${paramValue}')`);
-                }
-                // Case 4: patient=http://example.com/fhir/Patient/123 (absolute URL) - NOT SUPPORTED YET
-                else if paramValue.includes("://") {
-                    return error(string `Invalid reference: absolute URL '${paramValue}' is not supported for parameter '${paramName}'. Use relative references instead (e.g., '${paramName}=Patient/123')`);
+                if parts.length() == 2 && parts[0] != "" && parts[1] != "" {
+                    targetType = parts[0];
+                    targetId = parts[1];
                 } else {
                     return error(string `Invalid reference format for parameter '${paramName}': '${paramValue}'`);
                 }
+            }
+            // Case 3: patient=123 (just the resource ID without type prefix) - NOT SUPPORTED YET
+            else if !paramValue.includes("://") {
+                return error(string `Invalid reference: search parameter '${paramName}' must include resource type (e.g., '${paramName}=Patient/123', not '${paramName}=${paramValue}')`);
+            }
+            // Case 4: patient=http://example.com/fhir/Patient/123 (absolute URL) - NOT SUPPORTED YET
+            else {
+                return error(string `Invalid reference: absolute URL '${paramValue}' is not supported for parameter '${paramName}'. Use relative references instead (e.g., '${paramName}=Patient/123')`);
+            }
 
-                if targetType != "" && targetId != "" {
+            if targetType != "" && targetId != "" {
 
-                    record {|string[] sourceExpressions; string|string[] validTargetTypes;|} refInfo = check self.getSourceExpressionsAndTargetTypes(jdbcClient, resourceType, paramName);
+                // For old-format references (e.g. paramName="Patient/123"), derive the search param name
+                // from the target resource type (e.g. "patient"). If old-format support is removed, use paramName directly.
+                record {|string[] sourceExpressions; string|string[] validTargetTypes;|} refInfo = check self.getSourceExpressionsAndTargetTypes(jdbcClient, resourceType, paramName.includes("/") ? targetType.toLowerAscii() : paramName);
 
                     // "any" means no resolve() is constraint in the expression 
                     // The target type is still implicitly filtered in the REFERENCES query via TARGET_RESOURCE_TYPE,
@@ -224,9 +217,7 @@ public class ReadMapper {
                         matchingResourceIds = intersection;
                     }
                 }
-            }
         }
-
         // If reference parameters were used but no matches found, return empty bundle
         if hasReferenceParams && (matchingResourceIds is string[] && matchingResourceIds.length() == 0) {
             json bundle = {
@@ -314,14 +305,7 @@ public class ReadMapper {
                 continue;
             }
 
-            // Skip reference parameters — already processed in the reference loop above
             boolean isTokenParam = paramValue.includes("|");
-            var paramDef = check self.getSearchParamDef(jdbcClient, resourceType, paramName);
-            boolean isRefParam = paramDef?.paramType == "reference";
-
-            if isRefParam && !isTokenParam {
-                continue;
-            }
 
             // Skip _count parameter (sent by default) and _include/_revinclude/_profile parameters (handled separately after main search)
             if paramName == "_count" || paramName == "_include" || paramName == "_revinclude" || paramName == "_profile" {

--- a/miscellaneous/fhir-server/modules/utils/commons.bal
+++ b/miscellaneous/fhir-server/modules/utils/commons.bal
@@ -19,8 +19,7 @@ const string LAST_UPDATED_COLUMN = "LAST_UPDATED";
 
 // Escape single quotes in SQL string values to prevent SQL injection
 public isolated function escapeSql(string value) returns string {
-    string escaped = regex:replaceAll(value, "'", "''");
-    return regex:replaceAll(escaped, "%", "\\%");
+    return regex:replaceAll(value, "'", "''");
 }
 
 // Validate and return JDBC client or throw error

--- a/miscellaneous/fhir-server/modules/utils/commons.bal
+++ b/miscellaneous/fhir-server/modules/utils/commons.bal
@@ -19,7 +19,8 @@ const string LAST_UPDATED_COLUMN = "LAST_UPDATED";
 
 // Escape single quotes in SQL string values to prevent SQL injection
 public isolated function escapeSql(string value) returns string {
-    return regex:replaceAll(value, "'", "''");
+    string escaped = regex:replaceAll(value, "'", "''");
+    return regex:replaceAll(escaped, "%", "\\%");
 }
 
 // Validate and return JDBC client or throw error

--- a/miscellaneous/fhir-server/service.bal
+++ b/miscellaneous/fhir-server/service.bal
@@ -577,7 +577,12 @@ isolated function performResourceSearch(string resourceType, r4:FHIRContext fhir
         } else {
             string errorMsg = searchResult.message();
             log:printError("Search failed: " + errorMsg);
-            return r4:createFHIRError(string `Failed to search ${resourceType} - ${errorMsg}`, r4:ERROR, r4:PROCESSING, httpStatusCode = http:STATUS_BAD_REQUEST);
+
+            // Check if error is related to invalid search parameters (validation failure)
+            if errorMsg.includes("does not exist") || errorMsg.includes("Invalid reference") {
+                return r4:createFHIRError(errorMsg, r4:ERROR, r4:INVALID, httpStatusCode = http:STATUS_BAD_REQUEST);
+            }
+            return r4:createFHIRError(string `Failed to search ${resourceType}`, r4:ERROR, r4:PROCESSING, httpStatusCode = http:STATUS_INTERNAL_SERVER_ERROR);
         }
     } on fail error e {
         log:printError("Error processing search: " + e.message());

--- a/miscellaneous/fhir-server/service.bal
+++ b/miscellaneous/fhir-server/service.bal
@@ -577,7 +577,7 @@ isolated function performResourceSearch(string resourceType, r4:FHIRContext fhir
         } else {
             string errorMsg = searchResult.message();
             log:printError("Search failed: " + errorMsg);
-            return r4:createFHIRError(string `Failed to search ${resourceType}`, r4:ERROR, r4:PROCESSING, httpStatusCode = http:STATUS_INTERNAL_SERVER_ERROR);
+            return r4:createFHIRError(string `Failed to search ${resourceType} - ${errorMsg}`, r4:ERROR, r4:PROCESSING, httpStatusCode = http:STATUS_BAD_REQUEST);
         }
     } on fail error e {
         log:printError("Error processing search: " + e.message());

--- a/miscellaneous/fhir-server/tests/integration-tests.sh
+++ b/miscellaneous/fhir-server/tests/integration-tests.sh
@@ -1445,26 +1445,102 @@ echo "Reference search test resources created"
 print_test "Reference search: subject=Patient/<id> (relative reference, expect 2)"
 check_total "subject=Patient/<id>" 2 "$(get_total "$BASE_URL/Condition?subject=Patient/$REF_PAT1_ID")"
 
-print_test "Reference search: subject=<id> plain (any type - not supported yet, expect err)"
-# check_total "subject=<id> plain" err "$(get_total "$BASE_URL/Condition?subject=$REF_PAT1_ID")"
-HTTP_CODE=$(curl -s -w "%{http_code}" -o /dev/null "$BASE_URL/Condition?subject=$REF_PAT1_ID")
-if [ "$HTTP_CODE" = "400" ]; then
-    print_pass "subject=<id> without type correctly rejected (HTTP $HTTP_CODE)"
+# --- Case 2 malformed: paramValue has slash but fails the 2-part / non-empty check ---
+print_test "Reference search: subject=Patient/ (trailing slash, expect 400)"
+RESPONSE=$(curl -s -w "\n%{http_code}" "$BASE_URL/Condition?subject=Patient/")
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | head -n -1)
+if [ "$HTTP_CODE" = "400" ] && echo "$BODY" | grep -q '"OperationOutcome"'; then
+    print_pass "subject=Patient/ (trailing slash) correctly rejected (HTTP $HTTP_CODE, OperationOutcome returned)"
+elif [ "$HTTP_CODE" != "400" ]; then
+    print_fail "subject=Patient/ should return 400, got $HTTP_CODE"
 else
-    print_fail "Unexpected response for subject=<id> without type (HTTP $HTTP_CODE)"
+    print_fail "subject=Patient/ returned 400 but response is not OperationOutcome: $BODY"
 fi
 
-print_test "Reference search: subject=non-existing-id no slash (non existing id, expect 0)"
-# check_total "subject=Patient<id> no slash" 0 "$(get_total "$BASE_URL/Condition?subject=non-existing-id")"
-HTTP_CODE=$(curl -s -w "%{http_code}" -o /dev/null "$BASE_URL/Condition?subject=non-existing-id")
-if [ "$HTTP_CODE" = "400" ]; then
-    print_pass "subject=non-existing-id without type correctly rejected (HTTP $HTTP_CODE)"
+print_test "Reference search: subject=/123 (leading slash, expect 400)"
+RESPONSE=$(curl -s -w "\n%{http_code}" "$BASE_URL/Condition?subject=/123")
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | head -n -1)
+if [ "$HTTP_CODE" = "400" ] && echo "$BODY" | grep -q '"OperationOutcome"'; then
+    print_pass "subject=/123 (leading slash) correctly rejected (HTTP $HTTP_CODE, OperationOutcome returned)"
+elif [ "$HTTP_CODE" != "400" ]; then
+    print_fail "subject=/123 should return 400, got $HTTP_CODE"
 else
-    print_fail "Unexpected response for subject=non-existing-id without type (HTTP $HTTP_CODE)"
+    print_fail "subject=/123 returned 400 but response is not OperationOutcome: $BODY"
+fi
+
+print_test "Reference search: subject=Patient/123/456 (too many segments, expect 400)"
+RESPONSE=$(curl -s -w "\n%{http_code}" "$BASE_URL/Condition?subject=Patient/123/456")
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | head -n -1)
+if [ "$HTTP_CODE" = "400" ] && echo "$BODY" | grep -q '"OperationOutcome"'; then
+    print_pass "subject=Patient/123/456 (too many segments) correctly rejected (HTTP $HTTP_CODE, OperationOutcome returned)"
+elif [ "$HTTP_CODE" != "400" ]; then
+    print_fail "subject=Patient/123/456 should return 400, got $HTTP_CODE"
+else
+    print_fail "subject=Patient/123/456 returned 400 but response is not OperationOutcome: $BODY"
+fi
+
+# --- Case 3: plain ID without type (not supported) ---
+print_test "Reference search: subject=<id> plain (no type prefix, expect 400)"
+RESPONSE=$(curl -s -w "\n%{http_code}" "$BASE_URL/Condition?subject=$REF_PAT1_ID")
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | head -n -1)
+if [ "$HTTP_CODE" = "400" ] && echo "$BODY" | grep -q '"OperationOutcome"'; then
+    print_pass "subject=<id> without type correctly rejected (HTTP $HTTP_CODE, OperationOutcome returned)"
+elif [ "$HTTP_CODE" != "400" ]; then
+    print_fail "subject=<id> without type should return 400, got $HTTP_CODE"
+else
+    print_fail "subject=<id> without type returned 400 but response is not OperationOutcome: $BODY"
+fi
+
+print_test "Reference search: subject=non-existing-id (plain non-existing id, expect 400)"
+RESPONSE=$(curl -s -w "\n%{http_code}" "$BASE_URL/Condition?subject=non-existing-id")
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | head -n -1)
+if [ "$HTTP_CODE" = "400" ] && echo "$BODY" | grep -q '"OperationOutcome"'; then
+    print_pass "subject=non-existing-id without type correctly rejected (HTTP $HTTP_CODE, OperationOutcome returned)"
+elif [ "$HTTP_CODE" != "400" ]; then
+    print_fail "subject=non-existing-id without type should return 400, got $HTTP_CODE"
+else
+    print_fail "subject=non-existing-id without type returned 400 but response is not OperationOutcome: $BODY"
 fi
 
 print_test "Reference search: patient=Patient/<id> (relative reference, expect 2)"
 check_total "patient=Patient/<id>" 2 "$(get_total "$BASE_URL/Condition?patient=Patient/$REF_PAT1_ID")"
+
+# --- Case 1: old format where paramName itself is "Patient/<id>" ---
+print_test "Reference search: old-format ?Patient/<PAT1> as param key (expect 2)"
+check_total "old-format ?Patient/<PAT1>" 2 "$(get_total "$BASE_URL/Condition?Patient/$REF_PAT1_ID")"
+
+print_test "Reference search: old-format ?Patient/<PAT2> as param key (expect 1)"
+check_total "old-format ?Patient/<PAT2>" 1 "$(get_total "$BASE_URL/Condition?Patient/$REF_PAT2_ID")"
+
+# Malformed old-format inputs:
+print_test "Reference search: old-format ?Patient/ (trailing slash, expect 400)"
+RESPONSE=$(curl -s -w "\n%{http_code}" "$BASE_URL/Condition?Patient/")
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | head -n -1)
+if [ "$HTTP_CODE" = "400" ] && echo "$BODY" | grep -q '"OperationOutcome"'; then
+    print_pass "Old-format ?Patient/ (trailing slash) correctly rejected (HTTP $HTTP_CODE, OperationOutcome returned)"
+elif [ "$HTTP_CODE" != "400" ]; then
+    print_fail "Old-format ?Patient/ should return 400, got $HTTP_CODE"
+else
+    print_fail "Old-format ?Patient/ returned 400 but response is not OperationOutcome: $BODY"
+fi
+
+print_test "Reference search: old-format ?Patient/123/456 (too many segments, expect 400)"
+RESPONSE=$(curl -s -w "\n%{http_code}" "$BASE_URL/Condition?Patient/123/456")
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | head -n -1)
+if [ "$HTTP_CODE" = "400" ] && echo "$BODY" | grep -q '"OperationOutcome"'; then
+    print_pass "Old-format ?Patient/123/456 (too many segments) correctly rejected (HTTP $HTTP_CODE, OperationOutcome returned)"
+elif [ "$HTTP_CODE" != "400" ]; then
+    print_fail "Old-format ?Patient/123/456 should return 400, got $HTTP_CODE"
+else
+    print_fail "Old-format ?Patient/123/456 returned 400 but response is not OperationOutcome: $BODY"
+fi
 
 
 # --- non-reference parameter given a Type/id value must not match ---
@@ -1483,13 +1559,13 @@ check_total "clinical-status=Patient/<id>" 0 "$(get_total "$BASE_URL/Condition?c
 print_test "Reference search: subject=Patient/<PAT2> (expect 1)"
 check_total "subject=Patient/<PAT2>" 1 "$(get_total "$BASE_URL/Condition?subject=Patient/$REF_PAT2_ID")"
 
-# --- Absolute URL reference must be rejected since we are not supporting it yet ---
-# TODO Add this later
-# print_test "Reference search: subject=http://example.com/fhir/Patient/<id> (absolute URL, expect 400)"
-# HTTP_CODE=$(curl -s -w "%{http_code}" -o /dev/null "$BASE_URL/Condition?subject=http://example.com/fhir/Patient/$REF_PAT1_ID")
-# if [ "$HTTP_CODE" = "400" ]; then
-#     print_pass "Absolute URL reference correctly rejected (HTTP $HTTP_CODE)"
-# else
+# --- Case 4: absolute URL reference (not supported) ---
+# TODO: uncomment after fixing regex issue in r4
+#print_test "Reference search: subject=http://example.com/fhir/Patient/<id> (absolute URL, expect 400)"
+#HTTP_CODE=$(curl -s -w "%{http_code}" -o /dev/null "$BASE_URL/Condition?subject=http://example.com/fhir/Patient/$REF_PAT1_ID")
+#if [ "$HTTP_CODE" = "400" ]; then
+#    print_pass "Absolute URL reference correctly rejected (HTTP $HTTP_CODE)"
+#else
 #     print_fail "Absolute URL reference should return 400, got $HTTP_CODE"
 # fi
 

--- a/miscellaneous/fhir-server/tests/integration-tests.sh
+++ b/miscellaneous/fhir-server/tests/integration-tests.sh
@@ -1470,18 +1470,6 @@ else
     print_fail "subject=/123 returned 400 but response is not OperationOutcome: $BODY"
 fi
 
-print_test "Reference search: subject=Patient/123/456 (too many segments, expect 400)"
-RESPONSE=$(curl -s -w "\n%{http_code}" "$BASE_URL/Condition?subject=Patient/123/456")
-HTTP_CODE=$(echo "$RESPONSE" | tail -1)
-BODY=$(echo "$RESPONSE" | head -n -1)
-if [ "$HTTP_CODE" = "400" ] && echo "$BODY" | grep -q '"OperationOutcome"'; then
-    print_pass "subject=Patient/123/456 (too many segments) correctly rejected (HTTP $HTTP_CODE, OperationOutcome returned)"
-elif [ "$HTTP_CODE" != "400" ]; then
-    print_fail "subject=Patient/123/456 should return 400, got $HTTP_CODE"
-else
-    print_fail "subject=Patient/123/456 returned 400 but response is not OperationOutcome: $BODY"
-fi
-
 # --- Case 3: plain ID without type (not supported) ---
 print_test "Reference search: subject=<id> plain (no type prefix, expect 400)"
 RESPONSE=$(curl -s -w "\n%{http_code}" "$BASE_URL/Condition?subject=$REF_PAT1_ID")
@@ -1509,39 +1497,6 @@ fi
 
 print_test "Reference search: patient=Patient/<id> (relative reference, expect 2)"
 check_total "patient=Patient/<id>" 2 "$(get_total "$BASE_URL/Condition?patient=Patient/$REF_PAT1_ID")"
-
-# --- Case 1: old format where paramName itself is "Patient/<id>" ---
-print_test "Reference search: old-format ?Patient/<PAT1> as param key (expect 2)"
-check_total "old-format ?Patient/<PAT1>" 2 "$(get_total "$BASE_URL/Condition?Patient/$REF_PAT1_ID")"
-
-print_test "Reference search: old-format ?Patient/<PAT2> as param key (expect 1)"
-check_total "old-format ?Patient/<PAT2>" 1 "$(get_total "$BASE_URL/Condition?Patient/$REF_PAT2_ID")"
-
-# Malformed old-format inputs:
-print_test "Reference search: old-format ?Patient/ (trailing slash, expect 400)"
-RESPONSE=$(curl -s -w "\n%{http_code}" "$BASE_URL/Condition?Patient/")
-HTTP_CODE=$(echo "$RESPONSE" | tail -1)
-BODY=$(echo "$RESPONSE" | head -n -1)
-if [ "$HTTP_CODE" = "400" ] && echo "$BODY" | grep -q '"OperationOutcome"'; then
-    print_pass "Old-format ?Patient/ (trailing slash) correctly rejected (HTTP $HTTP_CODE, OperationOutcome returned)"
-elif [ "$HTTP_CODE" != "400" ]; then
-    print_fail "Old-format ?Patient/ should return 400, got $HTTP_CODE"
-else
-    print_fail "Old-format ?Patient/ returned 400 but response is not OperationOutcome: $BODY"
-fi
-
-print_test "Reference search: old-format ?Patient/123/456 (too many segments, expect 400)"
-RESPONSE=$(curl -s -w "\n%{http_code}" "$BASE_URL/Condition?Patient/123/456")
-HTTP_CODE=$(echo "$RESPONSE" | tail -1)
-BODY=$(echo "$RESPONSE" | head -n -1)
-if [ "$HTTP_CODE" = "400" ] && echo "$BODY" | grep -q '"OperationOutcome"'; then
-    print_pass "Old-format ?Patient/123/456 (too many segments) correctly rejected (HTTP $HTTP_CODE, OperationOutcome returned)"
-elif [ "$HTTP_CODE" != "400" ]; then
-    print_fail "Old-format ?Patient/123/456 should return 400, got $HTTP_CODE"
-else
-    print_fail "Old-format ?Patient/123/456 returned 400 but response is not OperationOutcome: $BODY"
-fi
-
 
 # --- non-reference parameter given a Type/id value must not match ---
 

--- a/miscellaneous/fhir-server/tests/integration-tests.sh
+++ b/miscellaneous/fhir-server/tests/integration-tests.sh
@@ -73,7 +73,7 @@ start_server() {
     SERVER_STARTED=true
     
     echo "Waiting for server to start (PID: $SERVER_PID)..."
-    for i in {1..30}; do
+    for i in {1..60}; do
         if curl -s "$BASE_URL/metadata" > /dev/null 2>&1; then
             print_pass "Server started successfully"
             return 0
@@ -82,7 +82,7 @@ start_server() {
         echo -n "."
     done
     echo ""
-    print_fail "Server failed to start within 30 seconds"
+    print_fail "Server failed to start within 60 seconds"
     cat server.log
     exit 1
 }
@@ -1377,6 +1377,159 @@ for RES in "Condition/$EXPORT_COND_ID" "MedicationRequest/$EXPORT_MEDREQ_ID" "Ob
     curl -s -w "%{http_code}" -o /dev/null -X DELETE "$BASE_URL/$RES" > /dev/null
 done
 echo "Export test resources cleaned up"
+
+# ======================================================================
+# Search Tests with Reference Parameter 
+# ======================================================================
+
+# IDs used only by this section — kept predictable for count assertions
+REF_PAT1_ID="test-ref-pat-001"
+REF_PAT2_ID="test-ref-pat-002"
+REF_COND1_ID="test-ref-cond-001"   # subject=PAT1, clinicalStatus=active
+REF_COND2_ID="test-ref-cond-002"   # subject=PAT1, clinicalStatus=inactive
+REF_COND3_ID="test-ref-cond-003"   # subject=PAT2, clinicalStatus=active
+
+# Helper: extract .total from a FHIR search response
+get_total() {
+    local url="$1"
+    local response=$(curl -s "$url")
+    local total=$(echo "$response" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('total','err'))" 2>/dev/null)
+
+    if [ "$DEBUG" = "true" ]; then
+        echo "$response" | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'DEBUG: {len(d.get(\"entry\", []))} results (total={d.get(\"total\", 0)}):'); [print(f'  - {e[\"resource\"][\"id\"]}: {e[\"resource\"].get(\"clinicalStatus\", {}).get(\"coding\", [{}])[0].get(\"code\", \"N/A\")}') for e in d.get('entry', [])]" 2>/dev/null >&2
+    fi
+
+    echo "$total"
+}
+
+# Helper: assert total equals expected
+check_total() {
+    local desc="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "$actual" = "$expected" ]; then
+        print_pass "$desc (total=$actual)"
+    else
+        print_fail "$desc (expected total=$expected, got=$actual)"
+    fi
+}
+
+# --- Setup: create reference search test resources (not counted as tests) ---
+echo ""
+echo "Setting up reference search test resources..."
+
+curl -s -o /dev/null -X POST "$BASE_URL/Patient" \
+  -H "Content-Type: application/fhir+json" \
+  -d "{\"resourceType\":\"Patient\",\"id\":\"$REF_PAT1_ID\",\"active\":true,\"name\":[{\"family\":\"RefTest\",\"given\":[\"Alice\"]}],\"gender\":\"female\"}"
+
+curl -s -o /dev/null -X POST "$BASE_URL/Patient" \
+  -H "Content-Type: application/fhir+json" \
+  -d "{\"resourceType\":\"Patient\",\"id\":\"$REF_PAT2_ID\",\"active\":true,\"name\":[{\"family\":\"RefTest\",\"given\":[\"Bob\"]}],\"gender\":\"male\"}"
+
+curl -s -o /dev/null -X POST "$BASE_URL/Condition" \
+  -H "Content-Type: application/fhir+json" \
+  -d "{\"resourceType\":\"Condition\",\"id\":\"$REF_COND1_ID\",\"clinicalStatus\":{\"coding\":[{\"system\":\"http://terminology.hl7.org/CodeSystem/condition-clinical\",\"code\":\"active\"}]},\"code\":{\"coding\":[{\"system\":\"http://snomed.info/sct\",\"code\":\"73211009\",\"display\":\"Diabetes mellitus\"}]},\"subject\":{\"reference\":\"Patient/$REF_PAT1_ID\"}}"
+
+curl -s -o /dev/null -X POST "$BASE_URL/Condition" \
+  -H "Content-Type: application/fhir+json" \
+  -d "{\"resourceType\":\"Condition\",\"id\":\"$REF_COND2_ID\",\"clinicalStatus\":{\"coding\":[{\"system\":\"http://terminology.hl7.org/CodeSystem/condition-clinical\",\"code\":\"inactive\"}]},\"code\":{\"coding\":[{\"system\":\"http://snomed.info/sct\",\"code\":\"44054006\",\"display\":\"Type 2 diabetes\"}]},\"subject\":{\"reference\":\"Patient/$REF_PAT1_ID\"}}"
+
+curl -s -o /dev/null -X POST "$BASE_URL/Condition" \
+  -H "Content-Type: application/fhir+json" \
+  -d "{\"resourceType\":\"Condition\",\"id\":\"$REF_COND3_ID\",\"clinicalStatus\":{\"coding\":[{\"system\":\"http://terminology.hl7.org/CodeSystem/condition-clinical\",\"code\":\"active\"}]},\"code\":{\"coding\":[{\"system\":\"http://snomed.info/sct\",\"code\":\"38341003\",\"display\":\"Hypertension\"}]},\"subject\":{\"reference\":\"Patient/$REF_PAT2_ID\"}}"
+
+echo "Reference search test resources created"
+
+# --- Reference parameter search tests ---
+
+print_test "Reference search: subject=Patient/<id> (relative reference, expect 2)"
+check_total "subject=Patient/<id>" 2 "$(get_total "$BASE_URL/Condition?subject=Patient/$REF_PAT1_ID")"
+
+print_test "Reference search: subject=<id> plain (any type - not supported yet, expect err)"
+# check_total "subject=<id> plain" err "$(get_total "$BASE_URL/Condition?subject=$REF_PAT1_ID")"
+HTTP_CODE=$(curl -s -w "%{http_code}" -o /dev/null "$BASE_URL/Condition?subject=$REF_PAT1_ID")
+if [ "$HTTP_CODE" = "400" ]; then
+    print_pass "subject=<id> without type correctly rejected (HTTP $HTTP_CODE)"
+else
+    print_fail "Unexpected response for subject=<id> without type (HTTP $HTTP_CODE)"
+fi
+
+print_test "Reference search: subject=non-existing-id no slash (non existing id, expect 0)"
+# check_total "subject=Patient<id> no slash" 0 "$(get_total "$BASE_URL/Condition?subject=non-existing-id")"
+HTTP_CODE=$(curl -s -w "%{http_code}" -o /dev/null "$BASE_URL/Condition?subject=non-existing-id")
+if [ "$HTTP_CODE" = "400" ]; then
+    print_pass "subject=non-existing-id without type correctly rejected (HTTP $HTTP_CODE)"
+else
+    print_fail "Unexpected response for subject=non-existing-id without type (HTTP $HTTP_CODE)"
+fi
+
+print_test "Reference search: patient=Patient/<id> (relative reference, expect 2)"
+check_total "patient=Patient/<id>" 2 "$(get_total "$BASE_URL/Condition?patient=Patient/$REF_PAT1_ID")"
+
+
+# --- non-reference parameter given a Type/id value must not match ---
+
+print_test "Non-ref param: code=Patient/<id> (expect 0)"
+check_total "code=Patient/<id>" 0 "$(get_total "$BASE_URL/Condition?code=Patient/$REF_PAT1_ID")"
+
+print_test "Non-ref param: category=Patient/<id> (expect 0)"
+check_total "category=Patient/<id>" 0 "$(get_total "$BASE_URL/Condition?category=Patient/$REF_PAT1_ID")"
+
+print_test "Non-ref param: clinical-status=Patient/<id> (expect 0)"
+check_total "clinical-status=Patient/<id>" 0 "$(get_total "$BASE_URL/Condition?clinical-status=Patient/$REF_PAT1_ID")"
+
+# --- Sanity: per-patient counts ---
+
+print_test "Reference search: subject=Patient/<PAT2> (expect 1)"
+check_total "subject=Patient/<PAT2>" 1 "$(get_total "$BASE_URL/Condition?subject=Patient/$REF_PAT2_ID")"
+
+# --- Absolute URL reference must be rejected since we are not supporting it yet ---
+# TODO Add this later
+# print_test "Reference search: subject=http://example.com/fhir/Patient/<id> (absolute URL, expect 400)"
+# HTTP_CODE=$(curl -s -w "%{http_code}" -o /dev/null "$BASE_URL/Condition?subject=http://example.com/fhir/Patient/$REF_PAT1_ID")
+# if [ "$HTTP_CODE" = "400" ]; then
+#     print_pass "Absolute URL reference correctly rejected (HTTP $HTTP_CODE)"
+# else
+#     print_fail "Absolute URL reference should return 400, got $HTTP_CODE"
+# fi
+
+# --- Invalid target resource type must be rejected ---
+# 'patient' on Condition has expression Condition.subject.where(resolve() is Patient),
+# so validTargetTypes=["Patient"]. Passing Medication as the type must return 400.
+# (Note: 'subject' on Condition has no resolve() constraint → validTargetTypes="any",
+#  so it would not reject Medication here.)
+
+print_test "Reference search: patient=Medication/<id> (disallowed target type for 'patient' param, expect 400)"
+HTTP_CODE=$(curl -s -w "%{http_code}" -o /dev/null "$BASE_URL/Condition?patient=Medication/$REF_PAT1_ID")
+if [ "$HTTP_CODE" = "400" ]; then
+    print_pass "Invalid target type correctly rejected (HTTP $HTTP_CODE)"
+else
+    print_fail "Invalid target type should return 400, got $HTTP_CODE"
+fi
+
+# 'subject' on Condition has no resolve() constraint (validTargetTypes="any"),
+# so an unknown type just returns 0 results rather than an error.
+print_test "Reference search: subject=Medication/<id> (unconstrained param, expect 0 results not error)"
+HTTP_CODE=$(curl -s -w "%{http_code}" -o /tmp/ref_test_resp.json "$BASE_URL/Condition?subject=Medication/nonexistent-med-id")
+if [ "$HTTP_CODE" = "200" ]; then
+    check_total "subject=Medication/<id> returns empty bundle" 0 "$(python3 -c "import sys,json; d=json.load(open('/tmp/ref_test_resp.json')); print(d.get('total','err'))" 2>/dev/null)"
+else
+    print_fail "subject=Medication/<id> should return 200 empty bundle, got $HTTP_CODE"
+fi
+
+# --- Non-existent target ID (valid format) must return 0, not an error ---
+
+print_test "Reference search: subject=Patient/does-not-exist (valid format, no data, expect 0)"
+check_total "subject=Patient/does-not-exist" 0 "$(get_total "$BASE_URL/Condition?subject=Patient/does-not-exist")"
+
+
+# --- Cleanup reference search test resources ---
+echo ""
+echo "Cleaning up reference search test resources..."
+for RES in "Condition/$REF_COND1_ID" "Condition/$REF_COND2_ID" "Condition/$REF_COND3_ID" "Patient/$REF_PAT1_ID" "Patient/$REF_PAT2_ID"; do
+    curl -s -o /dev/null -X DELETE "$BASE_URL/$RES"
+done
+echo "Reference search test resources cleaned up"
 
 # Summary
 echo ""


### PR DESCRIPTION
## Purpose
Fix incorrect handling of reference-type search parameters during search queries.                                                                                                          

Provide a fix for: https://github.com/wso2-enterprise/open-healthcare/issues/2091

Note that this fix can be improved in a more robust approach in the future after implementing https://github.com/wso2-enterprise/open-healthcare/issues/2096

## Goals
- Identify reference-type search parameters by querying SEARCH_PARAM_RES_EXPRESSIONS instead  of relying on a `/` heuristic in the parameter value.
- Prevent non-reference parameters (e.g. code, category) from being incorrectly routed to the REFERENCES table when their value contains a / . 
- Prevent skipping of reference param filtering in search if `/` is missed in parameter value.
- Return a not-supported message for parameter values that are not supported yet ( e.g. : `subject=<id>`, `subject=<absolute-path>`)

## Approach
Add a lookup against SEARCH_PARAM_RES_EXPRESSIONS table to determine whether a search parameter is of type reference. 

## Automation tests
 - Integration tests
     - Added reference search test cases to `tests/integration-tests.sh` covering correct reference queries, malformed values, non-reference params with Type/id values, and plain-id references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved classification and parsing of search parameters, with stricter validation and clearer rejections for malformed reference formats.
  * Enhanced reference resolution with type-constraint checks and safer ID filtering/escaping.
  * More specific error responses for invalid reference searches (returning 400) and clearer messages for search failures.

* **Tests**
  * Added integration tests covering reference-parameter searches, validation edge cases, type-constraint behavior, and cleanup.

* **Chores**
  * Increased server startup readiness polling timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->