### PR TITLE
FHIR Server Optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ Cloud.toml
 
 # Ignore export files
 miscellaneous/fhir-server/data/exports/*
+miscellaneous/fhir-server/agent/

--- a/miscellaneous/fhir-server/Dependencies.toml
+++ b/miscellaneous/fhir-server/Dependencies.toml
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.12.0"
+version = "2.12.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -106,7 +106,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.16.2"
+version = "2.16.3"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/miscellaneous/fhir-server/Dependencies.toml
+++ b/miscellaneous/fhir-server/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.10"
+distribution-version = "2201.13.3"
 
 [[package]]
 org = "ballerina"
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.10.1"
+version = "2.12.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -77,7 +77,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -91,7 +91,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "ftp"
-version = "2.17.1"
+version = "2.19.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "data.csv"},
@@ -100,14 +100,13 @@ dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "log"},
-	{org = "ballerina", name = "task"},
-	{org = "ballerina", name = "time"}
+	{org = "ballerina", name = "task"}
 ]
 
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.10"
+version = "2.16.2"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -243,6 +242,14 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "lang.transaction"
+version = "0.0.0"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.value"
 version = "0.0.0"
 dependencies = [
@@ -252,7 +259,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.14.0"
+version = "2.17.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -277,7 +284,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.14.1"
+version = "2.15.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -290,7 +297,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.6.0"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -307,7 +314,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "regex"
-version = "1.3.2"
+version = "1.4.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.string"}
@@ -319,7 +326,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "sql"
-version = "1.17.1"
+version = "1.19.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -386,6 +393,27 @@ modules = [
 ]
 
 [[package]]
+org = "ballerinai"
+name = "transaction"
+version = "0.0.0"
+dependencies = [
+	{org = "ballerina", name = "cache"},
+	{org = "ballerina", name = "http"},
+	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.runtime"},
+	{org = "ballerina", name = "lang.transaction"},
+	{org = "ballerina", name = "lang.value"},
+	{org = "ballerina", name = "log"},
+	{org = "ballerina", name = "task"},
+	{org = "ballerina", name = "time"},
+	{org = "ballerina", name = "uuid"}
+]
+modules = [
+	{org = "ballerinai", packageName = "transaction", moduleName = "transaction"}
+]
+
+[[package]]
 org = "ballerinax"
 name = "ballerina_fhir_server"
 version = "1.0.0"
@@ -401,6 +429,7 @@ dependencies = [
 	{org = "ballerina", name = "time"},
 	{org = "ballerina", name = "uuid"},
 	{org = "ballerinai", name = "observe"},
+	{org = "ballerinai", name = "transaction"},
 	{org = "ballerinax", name = "health.fhir.r4"},
 	{org = "ballerinax", name = "health.fhir.r4.international401"},
 	{org = "ballerinax", name = "health.fhir.r4.parser"},
@@ -554,7 +583,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "health.fhirr4"
-version = "3.0.7"
+version = "3.0.8"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
@@ -579,7 +608,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "java.jdbc"
-version = "1.14.1"
+version = "1.15.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/miscellaneous/fhir-server/Dependencies.toml
+++ b/miscellaneous/fhir-server/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.13.3"
+distribution-version = "2201.12.10"
 
 [[package]]
 org = "ballerina"
@@ -91,7 +91,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "ftp"
-version = "2.19.0"
+version = "2.17.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "data.csv"},
@@ -100,13 +100,14 @@ dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "log"},
-	{org = "ballerina", name = "task"}
+	{org = "ballerina", name = "task"},
+	{org = "ballerina", name = "time"}
 ]
 
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.16.3"
+version = "2.14.11"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -259,7 +260,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.17.0"
+version = "2.14.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -284,7 +285,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.15.0"
+version = "2.14.1"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -297,7 +298,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.1"
+version = "1.6.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -314,7 +315,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "regex"
-version = "1.4.3"
+version = "1.3.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.string"}
@@ -326,7 +327,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "sql"
-version = "1.19.0"
+version = "1.17.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -567,12 +568,13 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "health.fhir.r4utils.fhirpath"
-version = "4.0.0"
+version = "6.0.0"
 dependencies = [
-	{org = "ballerina", name = "io"},
-	{org = "ballerina", name = "lang.int"},
-	{org = "ballerina", name = "lang.regexp"},
+	{org = "ballerina", name = "http"},
+	{org = "ballerina", name = "lang.array"},
 	{org = "ballerina", name = "log"},
+	{org = "ballerina", name = "regex"},
+	{org = "ballerina", name = "time"},
 	{org = "ballerinax", name = "health.fhir.r4"},
 	{org = "ballerinax", name = "health.fhir.r4.validator"}
 ]
@@ -608,7 +610,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "java.jdbc"
-version = "1.15.1"
+version = "1.14.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/miscellaneous/fhir-server/modules/handlers/bundle_handler.bal
+++ b/miscellaneous/fhir-server/modules/handlers/bundle_handler.bal
@@ -32,6 +32,7 @@ public class BundleHandler {
     }
 
     public isolated function processBundle(json bundleJson) returns json|error {
+        log:printInfo("Processing FHIR bundle request"); 
         if !(bundleJson is map<json>) {
             return error("Bundle payload must be a JSON object");
         }
@@ -47,6 +48,9 @@ public class BundleHandler {
         }
 
         json entriesJson = bundleMap["entry"];
+        if entriesJson !is () && !(entriesJson is json[]) {  
+            return error("Bundle.entry must be an array");  
+        }
         json[] entries = entriesJson is json[] ? <json[]>entriesJson : [];
 
         map<string> placeholderMap = check self.assignIdsForPosts(entries);
@@ -54,6 +58,7 @@ public class BundleHandler {
 
         json[] responseEntries = [];
         if bundleType == "transaction" {
+            log:printInfo(string `Processing bundle as transaction with ${entries.length()} entries`);
             transaction {
                 foreach json entry in resolvedEntries {
                     json responseEntry = check self.processEntry(entry);

--- a/miscellaneous/fhir-server/modules/handlers/bundle_handler.bal
+++ b/miscellaneous/fhir-server/modules/handlers/bundle_handler.bal
@@ -1,0 +1,337 @@
+import ballerina/log;
+import ballerina/uuid;
+import ballerinax/java.jdbc;
+
+// WORK.md §5.3 / Phase 5 — Bundle transaction handler.
+//
+// FHIR `transaction` Bundles are the dominant ingest shape for Synthea
+// (~100-300 entries each). Without this handler, every entry is a separate
+// HTTP round-trip and a separate DB transaction → fsync amplification
+// dominates throughput. Wrapping all entries from one Bundle inside a
+// single Ballerina `transaction { ... check commit; }` amortizes fsync
+// across the whole Bundle, and any per-entry failure rolls the whole
+// thing back at the JDBC layer.
+//
+// Scope (intentional):
+//   - Supports `Bundle.type = transaction` (atomic) and `batch` (best-effort).
+//   - Dispatches POST / PUT / PATCH / DELETE to the existing handler core
+//     methods (`persistResource` / `persistUpdate` / `persistPatch` /
+//     `persistDelete`) — they don't open their own transaction blocks, so
+//     they participate in the Bundle's transaction.
+//   - Resolves `urn:uuid:` placeholder references for POST entries: every
+//     POST with `fullUrl: "urn:uuid:X"` is given an id (the resource's own
+//     id if present, else a fresh UUID), and every `reference: "urn:uuid:X"`
+//     elsewhere in the Bundle is rewritten to `ResourceType/id` before any
+//     DB work happens. This is the minimum needed to ingest Synthea bundles.
+//
+// Out of scope (deferred, will return 4xx if encountered):
+//   - Conditional create / update / delete (`If-None-Exist`, search-URL).
+//   - GET entries inside a transaction.
+//   - Bundle re-ordering by entry type per FHIR §3.2.0.16.2; entries are
+//     processed in the order received.
+public class BundleHandler {
+    private final jdbc:Client? jdbcClient;
+    private CreateHandler createHandler;
+    private UpdateHandler updateHandler;
+    private DeleteHandler deleteHandler;
+
+    public isolated function init(jdbc:Client? jdbcClient = ()) {
+        self.jdbcClient = jdbcClient;
+        self.createHandler = new CreateHandler(jdbcClient);
+        self.updateHandler = new UpdateHandler(jdbcClient);
+        self.deleteHandler = new DeleteHandler(jdbcClient);
+    }
+
+    public isolated function processBundle(json bundleJson) returns json|error {
+        if !(bundleJson is map<json>) {
+            return error("Bundle payload must be a JSON object");
+        }
+        map<json> bundleMap = <map<json>>bundleJson;
+
+        json typeJson = bundleMap["type"];
+        if !(typeJson is string) {
+            return error("Bundle.type is required and must be a string");
+        }
+        string bundleType = <string>typeJson;
+        if bundleType != "transaction" && bundleType != "batch" {
+            return error(string `Bundle.type must be 'transaction' or 'batch', got '${bundleType}'`);
+        }
+
+        json entriesJson = bundleMap["entry"];
+        json[] entries = entriesJson is json[] ? <json[]>entriesJson : [];
+
+        // Mint ids for POST entries with urn:uuid: placeholders, then rewrite
+        // any cross-entry references in resource bodies. Done once up front
+        // so the inserts inside the transaction can use real ids.
+        map<string> placeholderMap = check self.assignIdsForPosts(entries);
+        json[] resolvedEntries = self.rewriteReferences(entries, placeholderMap);
+
+        json[] responseEntries = [];
+        if bundleType == "transaction" {
+            transaction {
+                foreach json entry in resolvedEntries {
+                    json responseEntry = check self.processEntry(entry);
+                    responseEntries.push(responseEntry);
+                }
+                check commit;
+            } on fail error e {
+                log:printError(string `Bundle transaction failed: ${e.message()}`);
+                return e;
+            }
+        } else {
+            // batch: each entry independent — failures don't affect siblings.
+            foreach json entry in resolvedEntries {
+                json|error responseEntry = self.processEntry(entry);
+                if responseEntry is error {
+                    log:printWarn(string `Bundle batch entry failed: ${responseEntry.message()}`);
+                    responseEntries.push({
+                        response: {
+                            status: "400 Bad Request",
+                            outcome: {
+                                resourceType: "OperationOutcome",
+                                issue: [
+                                    {
+                                        severity: "error",
+                                        code: "processing",
+                                        diagnostics: responseEntry.message()
+                                    }
+                                ]
+                            }
+                        }
+                    });
+                } else {
+                    responseEntries.push(responseEntry);
+                }
+            }
+        }
+
+        return {
+            resourceType: "Bundle",
+            'type: bundleType + "-response",
+            entry: responseEntries
+        };
+    }
+
+    // For every POST entry whose fullUrl is a urn:uuid: placeholder, decide
+    // the id it will land at and remember it. Prefers the resource's own id
+    // when present (so client-assigned ids round-trip), otherwise mints a
+    // fresh v4 UUID. No DB writes here — pure planning.
+    private isolated function assignIdsForPosts(json[] entries) returns map<string>|error {
+        map<string> mapping = {};
+
+        foreach json entry in entries {
+            if !(entry is map<json>) {
+                continue;
+            }
+            map<json> entryMap = <map<json>>entry;
+
+            json fullUrlJson = entryMap["fullUrl"];
+            if !(fullUrlJson is string) {
+                continue;
+            }
+            string fullUrl = <string>fullUrlJson;
+            if !fullUrl.startsWith("urn:uuid:") {
+                continue;
+            }
+
+            json requestJson = entryMap["request"];
+            string method = "";
+            if requestJson is map<json> {
+                json methodJson = (<map<json>>requestJson)["method"];
+                if methodJson is string {
+                    method = (<string>methodJson).toUpperAscii();
+                }
+            }
+            if method != "POST" {
+                continue;
+            }
+
+            json resourceJson = entryMap["resource"];
+            if !(resourceJson is map<json>) {
+                continue;
+            }
+            map<json> resourceMap = <map<json>>resourceJson;
+
+            json resourceTypeJson = resourceMap["resourceType"];
+            if !(resourceTypeJson is string) {
+                return error(string `POST entry with fullUrl '${fullUrl}' missing resource.resourceType`);
+            }
+            string resourceType = <string>resourceTypeJson;
+
+            string id;
+            json idJson = resourceMap["id"];
+            if idJson is string && idJson != "" {
+                id = <string>idJson;
+            } else {
+                id = uuid:createType4AsString();
+            }
+            mapping[fullUrl] = string `${resourceType}/${id}`;
+        }
+
+        return mapping;
+    }
+
+    // Walk every entry and replace placeholder references with the real
+    // ResourceType/id form. Also stamps the resolved id back into the POST
+    // resource (so the create handler sees a concrete id) for any entry
+    // whose fullUrl was minted above.
+    private isolated function rewriteReferences(json[] entries, map<string> placeholderMap) returns json[] {
+        json[] rewritten = [];
+        foreach json entry in entries {
+            if !(entry is map<json>) {
+                rewritten.push(entry);
+                continue;
+            }
+            map<json> entryMap = (<map<json>>entry).clone();
+
+            json fullUrlJson = entryMap["fullUrl"];
+            if fullUrlJson is string {
+                string fullUrl = <string>fullUrlJson;
+                if placeholderMap.hasKey(fullUrl) {
+                    string resolvedRef = placeholderMap.get(fullUrl);
+                    int? slashIdx = resolvedRef.indexOf("/");
+                    if slashIdx is int {
+                        string resolvedId = resolvedRef.substring(slashIdx + 1);
+                        json resourceJson = entryMap["resource"];
+                        if resourceJson is map<json> {
+                            map<json> resourceMap = (<map<json>>resourceJson).clone();
+                            resourceMap["id"] = resolvedId;
+                            entryMap["resource"] = resourceMap;
+                        }
+                    }
+                }
+            }
+
+            json resourceJson2 = entryMap["resource"];
+            if resourceJson2 is map<json> || resourceJson2 is json[] {
+                entryMap["resource"] = self.replacePlaceholdersInJson(resourceJson2, placeholderMap);
+            }
+
+            rewritten.push(entryMap);
+        }
+        return rewritten;
+    }
+
+    // Recursively replace `"reference": "urn:uuid:X"` with the resolved
+    // value. Walks maps and arrays; leaves scalars alone.
+    private isolated function replacePlaceholdersInJson(json input, map<string> placeholderMap) returns json {
+        if input is map<json> {
+            map<json> result = {};
+            foreach var [key, value] in input.entries() {
+                if key == "reference" && value is string {
+                    string ref = <string>value;
+                    if placeholderMap.hasKey(ref) {
+                        result[key] = placeholderMap.get(ref);
+                        continue;
+                    }
+                }
+                result[key] = self.replacePlaceholdersInJson(value, placeholderMap);
+            }
+            return result;
+        }
+        if input is json[] {
+            json[] result = [];
+            foreach json item in input {
+                result.push(self.replacePlaceholdersInJson(item, placeholderMap));
+            }
+            return result;
+        }
+        return input;
+    }
+
+    private isolated function processEntry(json entry) returns json|error {
+        if !(entry is map<json>) {
+            return error("Bundle entry must be a JSON object");
+        }
+        map<json> entryMap = <map<json>>entry;
+
+        json requestJson = entryMap["request"];
+        if !(requestJson is map<json>) {
+            return error("Bundle entry missing required 'request' element");
+        }
+        map<json> requestMap = <map<json>>requestJson;
+
+        json methodJson = requestMap["method"];
+        json urlJson = requestMap["url"];
+        if !(methodJson is string) {
+            return error("Bundle entry request.method must be a string");
+        }
+        if !(urlJson is string) {
+            return error("Bundle entry request.url must be a string");
+        }
+        string method = (<string>methodJson).toUpperAscii();
+        string url = <string>urlJson;
+        json resourceJson = entryMap["resource"];
+
+        // FHIR transaction urls have the shape "ResourceType" (POST) or
+        // "ResourceType/id" (PUT / PATCH / DELETE / GET). Anything richer
+        // (search-URL conditional refs, ?_format, etc.) we don't yet handle.
+        string[] urlParts = re `/`.split(url);
+        if urlParts.length() == 0 || urlParts[0] == "" {
+            return error(string `Invalid Bundle entry URL: '${url}'`);
+        }
+        string resourceType = urlParts[0];
+
+        if method == "POST" {
+            json|error result = self.createHandler.persistResource(resourceType, resourceJson);
+            if result is error {
+                return result;
+            }
+            string createdId = "";
+            if result is map<json> {
+                json idJson = (<map<json>>result)["id"];
+                if idJson is string {
+                    createdId = <string>idJson;
+                }
+            }
+            return {
+                response: {
+                    status: "201 Created",
+                    location: string `${resourceType}/${createdId}`
+                },
+                'resource: result
+            };
+        }
+
+        if urlParts.length() < 2 || urlParts[1] == "" {
+            return error(string `${method} URL must be of the form 'ResourceType/id', got '${url}'`);
+        }
+        string id = urlParts[1];
+
+        if method == "PUT" {
+            string|error result = self.updateHandler.persistUpdate(resourceType, id, resourceJson);
+            if result is error {
+                return result;
+            }
+            return {
+                response: {
+                    status: "200 OK",
+                    location: string `${resourceType}/${id}`
+                },
+                'resource: resourceJson
+            };
+        }
+        if method == "PATCH" {
+            json|error result = self.updateHandler.persistPatch(resourceType, id, resourceJson);
+            if result is error {
+                return result;
+            }
+            return {
+                response: {
+                    status: "200 OK",
+                    location: string `${resourceType}/${id}`
+                },
+                'resource: result
+            };
+        }
+        if method == "DELETE" {
+            boolean|error result = self.deleteHandler.persistDelete(resourceType, id);
+            if result is error {
+                return result;
+            }
+            return {response: {status: "204 No Content"}};
+        }
+
+        return error(string `Unsupported Bundle entry method: ${method}`);
+    }
+}

--- a/miscellaneous/fhir-server/modules/handlers/bundle_handler.bal
+++ b/miscellaneous/fhir-server/modules/handlers/bundle_handler.bal
@@ -144,6 +144,10 @@ public class BundleHandler {
             }
             string resourceType = <string>resourceTypeJson;
 
+            if mapping.hasKey(fullUrl) {
+                return error(string `Duplicate urn:uuid placeholder '${fullUrl}' in bundle POST entries`);
+            }
+
             string id;
             json idJson = resourceMap["id"];
             if idJson is string && idJson != "" {

--- a/miscellaneous/fhir-server/modules/handlers/bundle_handler.bal
+++ b/miscellaneous/fhir-server/modules/handlers/bundle_handler.bal
@@ -1,34 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/log;
 import ballerina/uuid;
 import ballerinax/java.jdbc;
 
-// WORK.md §5.3 / Phase 5 — Bundle transaction handler.
-//
-// FHIR `transaction` Bundles are the dominant ingest shape for Synthea
-// (~100-300 entries each). Without this handler, every entry is a separate
-// HTTP round-trip and a separate DB transaction → fsync amplification
-// dominates throughput. Wrapping all entries from one Bundle inside a
-// single Ballerina `transaction { ... check commit; }` amortizes fsync
-// across the whole Bundle, and any per-entry failure rolls the whole
-// thing back at the JDBC layer.
-//
-// Scope (intentional):
-//   - Supports `Bundle.type = transaction` (atomic) and `batch` (best-effort).
-//   - Dispatches POST / PUT / PATCH / DELETE to the existing handler core
-//     methods (`persistResource` / `persistUpdate` / `persistPatch` /
-//     `persistDelete`) — they don't open their own transaction blocks, so
-//     they participate in the Bundle's transaction.
-//   - Resolves `urn:uuid:` placeholder references for POST entries: every
-//     POST with `fullUrl: "urn:uuid:X"` is given an id (the resource's own
-//     id if present, else a fresh UUID), and every `reference: "urn:uuid:X"`
-//     elsewhere in the Bundle is rewritten to `ResourceType/id` before any
-//     DB work happens. This is the minimum needed to ingest Synthea bundles.
-//
-// Out of scope (deferred, will return 4xx if encountered):
-//   - Conditional create / update / delete (`If-None-Exist`, search-URL).
-//   - GET entries inside a transaction.
-//   - Bundle re-ordering by entry type per FHIR §3.2.0.16.2; entries are
-//     processed in the order received.
 public class BundleHandler {
     private final jdbc:Client? jdbcClient;
     private CreateHandler createHandler;
@@ -60,9 +49,6 @@ public class BundleHandler {
         json entriesJson = bundleMap["entry"];
         json[] entries = entriesJson is json[] ? <json[]>entriesJson : [];
 
-        // Mint ids for POST entries with urn:uuid: placeholders, then rewrite
-        // any cross-entry references in resource bodies. Done once up front
-        // so the inserts inside the transaction can use real ids.
         map<string> placeholderMap = check self.assignIdsForPosts(entries);
         json[] resolvedEntries = self.rewriteReferences(entries, placeholderMap);
 
@@ -79,7 +65,6 @@ public class BundleHandler {
                 return e;
             }
         } else {
-            // batch: each entry independent — failures don't affect siblings.
             foreach json entry in resolvedEntries {
                 json|error responseEntry = self.processEntry(entry);
                 if responseEntry is error {
@@ -112,10 +97,6 @@ public class BundleHandler {
         };
     }
 
-    // For every POST entry whose fullUrl is a urn:uuid: placeholder, decide
-    // the id it will land at and remember it. Prefers the resource's own id
-    // when present (so client-assigned ids round-trip), otherwise mints a
-    // fresh v4 UUID. No DB writes here — pure planning.
     private isolated function assignIdsForPosts(json[] entries) returns map<string>|error {
         map<string> mapping = {};
 
@@ -171,10 +152,6 @@ public class BundleHandler {
         return mapping;
     }
 
-    // Walk every entry and replace placeholder references with the real
-    // ResourceType/id form. Also stamps the resolved id back into the POST
-    // resource (so the create handler sees a concrete id) for any entry
-    // whose fullUrl was minted above.
     private isolated function rewriteReferences(json[] entries, map<string> placeholderMap) returns json[] {
         json[] rewritten = [];
         foreach json entry in entries {
@@ -212,8 +189,6 @@ public class BundleHandler {
         return rewritten;
     }
 
-    // Recursively replace `"reference": "urn:uuid:X"` with the resolved
-    // value. Walks maps and arrays; leaves scalars alone.
     private isolated function replacePlaceholdersInJson(json input, map<string> placeholderMap) returns json {
         if input is map<json> {
             map<json> result = {};
@@ -263,9 +238,6 @@ public class BundleHandler {
         string url = <string>urlJson;
         json resourceJson = entryMap["resource"];
 
-        // FHIR transaction urls have the shape "ResourceType" (POST) or
-        // "ResourceType/id" (PUT / PATCH / DELETE / GET). Anything richer
-        // (search-URL conditional refs, ?_format, etc.) we don't yet handle.
         string[] urlParts = re `/`.split(url);
         if urlParts.length() == 0 || urlParts[0] == "" {
             return error(string `Invalid Bundle entry URL: '${url}'`);

--- a/miscellaneous/fhir-server/modules/handlers/create_handler.bal
+++ b/miscellaneous/fhir-server/modules/handlers/create_handler.bal
@@ -8,154 +8,114 @@ import ballerina/sql;
 import ballerinax/java.jdbc;
 
 public class CreateHandler {
-    private utils:TransactionHandler transactionHandler;
     private HistoryHandler historyHandler;
     private final jdbc:Client? jdbcClient;
 
     public isolated function init(jdbc:Client? jdbcClient = ()) {
         self.jdbcClient = jdbcClient;
-        self.transactionHandler = new utils:TransactionHandler();
         self.historyHandler = new HistoryHandler(jdbcClient);
     }
 
-    // Main function to save resource
+    // Public entry point for single-resource creates.
+    //
+    // WORK.md §5.1 / Phase 3: the whole pipeline is wrapped in a real
+    // Ballerina `transaction { ... check commit; }` block, so any failure
+    // (validation, FK violation, search-param extract, reference insert)
+    // rolls the JDBC connection back automatically — no application-level
+    // backup/restore needed.
     public isolated function saveResourceWithTransaction(string resourceType, json resourceJson) returns json|error {
-
-        // Begin transaction
-        utils:TransactionContext 'transaction = self.transactionHandler.beginTransaction();
-
-        do {
-            // Create mapper with jdbcClient
-            jdbc:Client validatedClient = check utils:getValidatedJdbcClient(self.jdbcClient);
-            mappers:CreateMapper mapper = new mappers:CreateMapper(validatedClient);
-            
-            // Map resource to insert model
-            log:printDebug(string `Mapping ${resourceType} to insert model`);
-            record {|anydata...;|}|error? insertModel = mapper.mapToInsertModel(
-                validatedClient, resourceType, resourceJson
-            );
-
-            if insertModel is () {
-                log:printError(string `Failed to create insert model for ${resourceType}: mapper returned null`);
-                return error(string `Failed to create insert model for ${resourceType}`);
-            }
-
-            if insertModel is error {
-                log:printError(string `Mapping failed for ${resourceType}: ${insertModel.message()}`);
-                return insertModel;
-            }
-
-            // Get extracted references and full resource JSON (with ID) after mapping
-            json[] references = mapper.getReferences();
-            json resourceWithId = mapper.getResourceJsonWithId();
-            log:printDebug(string `Extracted ${references.length()} reference(s) from ${resourceType}`);
-
-            // Save main resource
-            log:printDebug(string `Saving main ${resourceType} record`);
-            string resourceId = check self.saveMainResource(resourceType, insertModel);
-            'transaction.mainResourceId = resourceId;
-
-            log:printDebug(string `Created ${resourceType} with ID: ${resourceId}`);
-
-            // Register in RESOURCE_TABLE so the DB FK on REFERENCES is satisfiable.
-            // This replaces the old application-level validateReferences SELECT round-trip.
-            error? rtResult = utils:saveToResourceTable(self.jdbcClient, resourceType, resourceId);
-            if rtResult is error {
-                log:printError(string `Failed to register ${resourceType}/${resourceId} in RESOURCE_TABLE: ${rtResult.message()}`);
-                error? rollbackResult = self.transactionHandler.rollbackCreateTransaction(self.jdbcClient, 'transaction, resourceType);
-                if (rollbackResult is error) {
-                    log:printError(string `Rollback failed for ${resourceType}/${resourceId}: ${rollbackResult.message()}`);
-                }
-                return rtResult;
-            }
-
-            // Special handling for SearchParameter resources - sync to expressions table
-            if resourceType == "SearchParameter" {
-                log:printDebug(string `Syncing SearchParameter/${resourceId} to SEARCH_PARAM_RES_EXPRESSIONS`);
-                error? syncResult = utils:syncSearchParameterToExpressions(self.jdbcClient, resourceJson);
-                if syncResult is error {
-                    log:printError(string `Failed to sync SearchParameter/${resourceId}: ${syncResult.message()}`);
-                    error? rollbackResult = self.transactionHandler.rollbackCreateTransaction(self.jdbcClient, 'transaction, resourceType);
-                    if (rollbackResult is error) {
-                        log:printError(string `Rollback failed for ${resourceType}/${resourceId}: ${rollbackResult.message()}`);
-                    }
-                    return syncResult;
-                }
-                log:printInfo(string `Successfully synced SearchParameter/${resourceId} to expressions table`);
-            }
-
-            // Save to history after creation
-            log:printDebug(string `Saving initial version of ${resourceType}/${resourceId} to history`);
-            error? historyResult = self.historyHandler.saveToHistory(resourceType, resourceId, insertModel, "POST");
-            if historyResult is error {
-                log:printError(string `Failed to save history for ${resourceType}/${resourceId}: ${historyResult.message()}`);
-                error? rollbackResult = self.transactionHandler.rollbackCreateTransaction(self.jdbcClient, 'transaction, resourceType);
-                if (rollbackResult is error) {
-                    log:printError(string `Rollback failed for ${resourceType}/${resourceId}: ${rollbackResult.message()}`);
-                }
-                return historyResult;
-            }
-
-            // Extract and save search parameters for indexed searching
-            log:printDebug(string `Extracting search parameters for ${resourceType}/${resourceId}`);
-            error? extractResult = utils:extractSearchParametersForResource(validatedClient, resourceType, resourceId, resourceJson);
-            if extractResult is error {
-                log:printError(string `Failed to extract search parameters for ${resourceType}/${resourceId}: ${extractResult.message()}`);
-                error? rollbackResult = self.transactionHandler.rollbackCreateTransaction(self.jdbcClient, 'transaction, resourceType);
-                if (rollbackResult is error) {
-                    log:printError(string `Rollback failed for ${resourceType}/${resourceId}: ${rollbackResult.message()}`);
-                }
-                return extractResult;
-            }
-
-            // Save all references
-            log:printDebug(string `Saving ${references.length()} reference(s) for ${resourceType}/${resourceId}`);
-            error? refResult = utils:saveReferences(self.jdbcClient, references, resourceType, resourceId, 'transaction);
-
-            if refResult is error {
-                // Rollback on reference save failure
-                log:printError(string `Failed to save references for ${resourceType}/${resourceId}: ${refResult.message()}`);
-                error? rollbackResult = self.transactionHandler.rollbackCreateTransaction(self.jdbcClient, 'transaction, resourceType);
-                if (rollbackResult is error) {
-                    log:printError(string `Rollback failed for ${resourceType}/${resourceId}: ${rollbackResult.message()}`);
-                }
-                // Translate a DB FK violation into a descriptive client error so the
-                // service layer can return 422 instead of 500.
-                string refMsg = refResult.message();
-                if refMsg.includes("violates foreign key constraint") || refMsg.includes("FK_REFERENCES_TARGET") {
-                    return error(string `Unresolved reference: one or more TARGET resources referenced by ${resourceType}/${resourceId} do not exist. Ensure all referenced resources are created first.`);
-                }
-                return refResult;
-            }
-
-            // Commit transaction
-            log:printDebug(string `Committing transaction for ${resourceType}/${resourceId}`);
-            self.transactionHandler.commitTransaction('transaction, resourceType, resourceId);
-
-            log:printDebug(string `Successfully created ${resourceType}/${resourceId} with ${references.length()} reference(s)`);
-            return resourceWithId;
-
+        json result;
+        transaction {
+            result = check self.persistResource(resourceType, resourceJson);
+            check commit;
         } on fail error e {
-            // Rollback on any failure
             log:printError(string `Create transaction failed for ${resourceType}: ${e.message()}`);
-            error? rollbackResult = check self.transactionHandler.rollbackCreateTransaction(self.jdbcClient, 'transaction, resourceType);
-            if (rollbackResult is error) {
-                log:printError(string `Rollback failed during create transaction cleanup for ${resourceType}: ${rollbackResult.message()}`);
-            }
             return e;
         }
+        return result;
+    }
+
+    // Core create pipeline. Callable from inside an outer `transaction { }`
+    // block — used by the Bundle handler (Phase 5) so a multi-entry Bundle
+    // commits atomically as a single JDBC transaction.
+    public isolated function persistResource(string resourceType, json resourceJson) returns json|error {
+        // Create mapper with jdbcClient
+        jdbc:Client validatedClient = check utils:getValidatedJdbcClient(self.jdbcClient);
+        mappers:CreateMapper mapper = new mappers:CreateMapper(validatedClient);
+
+        // Map resource to insert model
+        log:printDebug(string `Mapping ${resourceType} to insert model`);
+        record {|anydata...;|}|error? insertModel = mapper.mapToInsertModel(
+                validatedClient, resourceType, resourceJson
+        );
+
+        if insertModel is () {
+            return error(string `Failed to create insert model for ${resourceType}: mapper returned null`);
+        }
+        if insertModel is error {
+            return insertModel;
+        }
+
+        // Get extracted references and full resource JSON (with ID) after mapping
+        json[] references = mapper.getReferences();
+        json resourceWithId = mapper.getResourceJsonWithId();
+        log:printDebug(string `Extracted ${references.length()} reference(s) from ${resourceType}`);
+
+        // Save main resource
+        string resourceId = check self.saveMainResource(resourceType, insertModel);
+        log:printDebug(string `Created ${resourceType} with ID: ${resourceId}`);
+
+        // Register in RESOURCE_TABLE so the DB FK on REFERENCES is satisfiable.
+        check utils:saveToResourceTable(self.jdbcClient, resourceType, resourceId);
+
+        // WORK.md §6 Phase 10: maintain the cross-type FHIR_RESOURCE_INDEX
+        // feed. PG-only; H2 short-circuits. Non-fatal — a transient failure
+        // here must not invalidate the write, so we swallow the error.
+        error? friResult = utils:upsertFhirResourceIndex(self.jdbcClient, resourceType, resourceId, 1);
+        if friResult is error {
+            log:printWarn(string `Failed to upsert FHIR_RESOURCE_INDEX for ${resourceType}/${resourceId}: ${friResult.message()} (non-fatal)`);
+        }
+
+        // Special handling for SearchParameter resources - sync to expressions table
+        if resourceType == "SearchParameter" {
+            log:printDebug(string `Syncing SearchParameter/${resourceId} to SEARCH_PARAM_RES_EXPRESSIONS`);
+            check utils:syncSearchParameterToExpressions(self.jdbcClient, resourceJson);
+            log:printInfo(string `Successfully synced SearchParameter/${resourceId} to expressions table`);
+        }
+
+        // Save to history after creation
+        check self.historyHandler.saveToHistory(resourceType, resourceId, insertModel, "POST");
+
+        // Extract and save search parameters for indexed searching
+        check utils:extractSearchParametersForResource(validatedClient, resourceType, resourceId, resourceJson);
+
+        // Save all references — translate FK violation to a descriptive error
+        // so the service layer can return 422 instead of 500.
+        utils:TransactionContext refCtx = utils:newTransactionContext();
+        refCtx.mainResourceId = resourceId;
+        error? refResult = utils:saveReferences(self.jdbcClient, references, resourceType, resourceId, refCtx);
+        if refResult is error {
+            string refMsg = refResult.message();
+            if refMsg.includes("violates foreign key constraint") || refMsg.includes("FK_REFERENCES_TARGET") {
+                return error(string `Unresolved reference: one or more TARGET resources referenced by ${resourceType}/${resourceId} do not exist. Ensure all referenced resources are created first.`);
+            }
+            return refResult;
+        }
+
+        log:printDebug(string `Successfully created ${resourceType}/${resourceId} with ${references.length()} reference(s)`);
+        return resourceWithId;
     }
 
     // Generic insert method
     private isolated function saveMainResource(string resourceType, record {|anydata...;|} insertModel) returns string|error {
-        
+
         // Get table name
         string tableName = mapperUtils:getTableName(resourceType);
         log:printDebug(string `Target table for ${resourceType}: ${tableName}`);
-        
+
         // Validate JDBC client
         jdbc:Client jdbcClient = check utils:getValidatedJdbcClient(self.jdbcClient);
-        
+
         // Get primary key value
         string primaryKeyColumn = mapperUtils:getPrimaryKeyColumn(resourceType);
         any resourceIdValue = insertModel[primaryKeyColumn];
@@ -164,14 +124,14 @@ public class CreateHandler {
         // Extract column names and values from insertModel
         string[] columnNames = insertModel.keys();
         anydata[] columnValues = insertModel.toArray();
-        
+
         log:printDebug(string `Prepared insert with ${columnNames.length()} columns for ${resourceType}/${resourceId}`);
-        
+
         // Build INSERT query string with quoted column names for PostgreSQL compatibility
         string[] quotedColumnNames = from string colName in columnNames
-                                      select string `"${colName}"`;
+            select string `"${colName}"`;
         string columnNamesStr = string:'join(", ", ...quotedColumnNames);
-        
+
         // Build values string using consolidated formatting utility
         string[] valueStrings = [];
         int index = 0;
@@ -185,16 +145,16 @@ public class CreateHandler {
             }
             index = index + 1;
         }
-        
+
         string valuesStr = string:'join(", ", ...valueStrings);
-        
+
         // Build complete INSERT query string with table name in double quotes
         string completeQueryStr = "INSERT INTO \"" + tableName + "\"(" + columnNamesStr + ") VALUES (" + valuesStr + ")";
         log:printDebug(string `Executing INSERT query for ${resourceType}/${resourceId}`);
-        
-        utils:RawSQLQuery rawQuery = new(completeQueryStr);
+
+        utils:RawSQLQuery rawQuery = new (completeQueryStr);
         sql:ExecutionResult|error result = jdbcClient->execute(rawQuery);
-        
+
         if result is error {
             string errMsg = result.message();
             string lowerMsg = errMsg.toLowerAscii();
@@ -205,10 +165,8 @@ public class CreateHandler {
             log:printError(string `Database insert failed for ${resourceType}/${resourceId}: ${errMsg}`);
             return result;
         }
-        
+
         log:printDebug(string `Successfully inserted ${resourceType}/${resourceId} into database`);
         return resourceId;
     }
 }
-
-

--- a/miscellaneous/fhir-server/modules/handlers/create_handler.bal
+++ b/miscellaneous/fhir-server/modules/handlers/create_handler.bal
@@ -33,6 +33,7 @@ public class CreateHandler {
     }
 
     public isolated function saveResourceWithTransaction(string resourceType, json resourceJson) returns json|error {
+        log:printInfo(string `Creating ${resourceType} resource`); 
         json result;
         transaction {
             result = check self.persistResource(resourceType, resourceJson);
@@ -104,7 +105,7 @@ public class CreateHandler {
             return refResult;
         }
 
-        log:printDebug(string `Successfully created ${resourceType}/${resourceId} with ${references.length()} reference(s)`);
+        log:printInfo(string `Successfully created ${resourceType}/${resourceId} with ${references.length()} reference(s)`);
         return resourceWithId;
     }
 

--- a/miscellaneous/fhir-server/modules/handlers/create_handler.bal
+++ b/miscellaneous/fhir-server/modules/handlers/create_handler.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina_fhir_server.mappers;
 import ballerina_fhir_server.utils;
 import ballerina_fhir_server.utils as mapperUtils;
@@ -16,13 +32,6 @@ public class CreateHandler {
         self.historyHandler = new HistoryHandler(jdbcClient);
     }
 
-    // Public entry point for single-resource creates.
-    //
-    // WORK.md §5.1 / Phase 3: the whole pipeline is wrapped in a real
-    // Ballerina `transaction { ... check commit; }` block, so any failure
-    // (validation, FK violation, search-param extract, reference insert)
-    // rolls the JDBC connection back automatically — no application-level
-    // backup/restore needed.
     public isolated function saveResourceWithTransaction(string resourceType, json resourceJson) returns json|error {
         json result;
         transaction {
@@ -35,9 +44,6 @@ public class CreateHandler {
         return result;
     }
 
-    // Core create pipeline. Callable from inside an outer `transaction { }`
-    // block — used by the Bundle handler (Phase 5) so a multi-entry Bundle
-    // commits atomically as a single JDBC transaction.
     public isolated function persistResource(string resourceType, json resourceJson) returns json|error {
         // Create mapper with jdbcClient
         jdbc:Client validatedClient = check utils:getValidatedJdbcClient(self.jdbcClient);
@@ -56,7 +62,6 @@ public class CreateHandler {
             return insertModel;
         }
 
-        // Get extracted references and full resource JSON (with ID) after mapping
         json[] references = mapper.getReferences();
         json resourceWithId = mapper.getResourceJsonWithId();
         log:printDebug(string `Extracted ${references.length()} reference(s) from ${resourceType}`);
@@ -68,9 +73,6 @@ public class CreateHandler {
         // Register in RESOURCE_TABLE so the DB FK on REFERENCES is satisfiable.
         check utils:saveToResourceTable(self.jdbcClient, resourceType, resourceId);
 
-        // WORK.md §6 Phase 10: maintain the cross-type FHIR_RESOURCE_INDEX
-        // feed. PG-only; H2 short-circuits. Non-fatal — a transient failure
-        // here must not invalidate the write, so we swallow the error.
         error? friResult = utils:upsertFhirResourceIndex(self.jdbcClient, resourceType, resourceId, 1);
         if friResult is error {
             log:printWarn(string `Failed to upsert FHIR_RESOURCE_INDEX for ${resourceType}/${resourceId}: ${friResult.message()} (non-fatal)`);

--- a/miscellaneous/fhir-server/modules/handlers/delete_handler.bal
+++ b/miscellaneous/fhir-server/modules/handlers/delete_handler.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina_fhir_server.utils;
 
 import ballerina/log;
@@ -13,12 +29,6 @@ public class DeleteHandler {
         self.historyHandler = new HistoryHandler(jdbcClient);
     }
 
-    // Public entry point for single-resource deletes.
-    //
-    // WORK.md §5.1 / Phase 3: a real Ballerina `transaction { }` block makes
-    // the multi-step delete (history snapshot → references → resource →
-    // FHIR_RESOURCE_INDEX tombstone) atomic. The previous backup/restore
-    // plumbing is gone — JDBC rollback handles failures.
     public isolated function deleteResourceWithTransaction(string resourceType, string resourceId) returns boolean|error {
         boolean result;
         transaction {
@@ -31,34 +41,23 @@ public class DeleteHandler {
         return result;
     }
 
-    // Core delete pipeline. Callable from inside an outer transaction (Bundle
-    // handler / Phase 5).
     public isolated function persistDelete(string resourceType, string resourceId) returns boolean|error {
-        // Check if resource exists
         boolean exists = check utils:resourceExists(self.jdbcClient, resourceType, resourceId);
         if !exists {
             log:printWarn(string `Delete attempted on non-existent resource: ${resourceType}/${resourceId}`);
             return error(string `${resourceType}/${resourceId} not found`);
         }
 
-        // Read the current row so we can write it to RESOURCE_HISTORY before
-        // deleting. Used purely for the history snapshot now — no longer for
-        // rollback (the JDBC transaction handles that).
         record {|anydata...;|} snapshot = check self.fetchResourceForHistory(resourceType, resourceId);
 
         int versionId = check int:fromString(snapshot.get("VERSION_ID").toString());
         log:printDebug(string `Saving version ${versionId} of ${resourceType}/${resourceId} to history before deletion`);
         check self.historyHandler.saveToHistory(resourceType, resourceId, snapshot, "DELETE");
 
-        // Bulk-delete outgoing references in one statement.
         utils:TransactionContext refCtx = utils:newTransactionContext();
         refCtx.mainResourceId = resourceId;
         check utils:deleteReferencesBySource(self.jdbcClient, resourceType, resourceId, refCtx);
 
-        // Delete search parameters for this resource. Non-fatal: drift in the
-        // search-param side tables is recoverable, but a failed primary delete
-        // must roll the whole transaction back — so search-param failures are
-        // only logged.
         jdbc:Client? jdbcConn = self.jdbcClient;
         if jdbcConn is jdbc:Client {
             error? deleteSearchResult = utils:deleteSearchParametersForResource(jdbcConn, resourceType, resourceId);
@@ -67,7 +66,6 @@ public class DeleteHandler {
             }
         }
 
-        // Special handling for SearchParameter resources - remove from expressions table
         if resourceType == "SearchParameter" {
             error? syncResult = utils:removeSearchParameterById(self.jdbcClient, resourceId);
             if syncResult is error {
@@ -77,19 +75,13 @@ public class DeleteHandler {
             }
         }
 
-        // Delete the main resource row.
         check utils:deleteResource(self.jdbcClient, resourceType, resourceId);
 
-        // Remove from RESOURCE_TABLE — ON DELETE CASCADE on REFERENCES
-        // cleans up rows pointing TO this resource.
         error? rtResult = utils:deleteFromResourceTable(self.jdbcClient, resourceType, resourceId);
         if rtResult is error {
             log:printWarn(string `Failed to remove ${resourceType}/${resourceId} from RESOURCE_TABLE: ${rtResult.message()} (non-fatal)`);
         }
 
-        // WORK.md §6 Phase 10: tombstone the row in FHIR_RESOURCE_INDEX so
-        // downstream cross-type history feeds can observe the deletion.
-        // PG-only; non-fatal.
         error? friResult = utils:markFhirResourceIndexDeleted(self.jdbcClient, resourceType, resourceId);
         if friResult is error {
             log:printWarn(string `Failed to mark FHIR_RESOURCE_INDEX deleted for ${resourceType}/${resourceId}: ${friResult.message()} (non-fatal)`);

--- a/miscellaneous/fhir-server/modules/handlers/delete_handler.bal
+++ b/miscellaneous/fhir-server/modules/handlers/delete_handler.bal
@@ -25,6 +25,7 @@ public class DeleteHandler {
     private final jdbc:Client? jdbcClient;
 
     public isolated function init(jdbc:Client? jdbcClient = ()) {
+        log:printDebug("Initializing DeleteHandler");
         self.jdbcClient = jdbcClient;
         self.historyHandler = new HistoryHandler(jdbcClient);
     }
@@ -42,6 +43,7 @@ public class DeleteHandler {
     }
 
     public isolated function persistDelete(string resourceType, string resourceId) returns boolean|error {
+        log:printInfo(string `Starting delete operation for ${resourceType}/${resourceId}`);
         boolean exists = check utils:resourceExists(self.jdbcClient, resourceType, resourceId);
         if !exists {
             log:printWarn(string `Delete attempted on non-existent resource: ${resourceType}/${resourceId}`);
@@ -77,10 +79,7 @@ public class DeleteHandler {
 
         check utils:deleteResource(self.jdbcClient, resourceType, resourceId);
 
-        error? rtResult = utils:deleteFromResourceTable(self.jdbcClient, resourceType, resourceId);
-        if rtResult is error {
-            log:printWarn(string `Failed to remove ${resourceType}/${resourceId} from RESOURCE_TABLE: ${rtResult.message()} (non-fatal)`);
-        }
+        check utils:deleteFromResourceTable(self.jdbcClient, resourceType, resourceId);
 
         error? friResult = utils:markFhirResourceIndexDeleted(self.jdbcClient, resourceType, resourceId);
         if friResult is error {

--- a/miscellaneous/fhir-server/modules/handlers/delete_handler.bal
+++ b/miscellaneous/fhir-server/modules/handlers/delete_handler.bal
@@ -5,165 +5,102 @@ import ballerina/sql;
 import ballerinax/java.jdbc;
 
 public class DeleteHandler {
-    private utils:TransactionHandler transactionHandler;
     private HistoryHandler historyHandler;
     private final jdbc:Client? jdbcClient;
 
     public isolated function init(jdbc:Client? jdbcClient = ()) {
         self.jdbcClient = jdbcClient;
-        self.transactionHandler = new utils:TransactionHandler();
         self.historyHandler = new HistoryHandler(jdbcClient);
     }
 
-    // Main function to delete resource with full transaction support
+    // Public entry point for single-resource deletes.
+    //
+    // WORK.md §5.1 / Phase 3: a real Ballerina `transaction { }` block makes
+    // the multi-step delete (history snapshot → references → resource →
+    // FHIR_RESOURCE_INDEX tombstone) atomic. The previous backup/restore
+    // plumbing is gone — JDBC rollback handles failures.
     public isolated function deleteResourceWithTransaction(string resourceType, string resourceId) returns boolean|error {
-
-        utils:TransactionContext 'transaction = self.transactionHandler.beginTransaction();
-        'transaction.mainResourceId = resourceId;
-
-        do {
-            // Check if resource exists
-            log:printDebug(string `Checking if ${resourceType}/${resourceId} exists`);
-            boolean exists = check self.checkResourceExists(resourceType, resourceId);
-
-            if !exists {
-                log:printWarn(string `Delete attempted on non-existent resource: ${resourceType}/${resourceId}`);
-                return error(string `${resourceType}/${resourceId} not found`);
-            }
-
-            // Backup before delete
-            log:printDebug(string `Backing up ${resourceType}/${resourceId} before deletion`);
-            record {|anydata...;|}? backup = check self.backupResource(resourceType, resourceId);
-            'transaction.backupResource = backup;
-            'transaction.backupReferences = check self.backupReferences(resourceType, resourceId);
-
-            // Save to history before deletion
-            if backup is record {|anydata...;|} {
-                int versionId = check int:fromString(backup.get("VERSION_ID").toString());
-                log:printDebug(string `Saving version ${versionId} of ${resourceType}/${resourceId} to history before deletion`);
-                error? historyResult = self.historyHandler.saveToHistory(resourceType, resourceId, backup, "DELETE");
-                if historyResult is error {
-                    log:printError(string `Failed to save history for ${resourceType}/${resourceId}: ${historyResult.message()}`);
-                    error? rollbackResult = self.transactionHandler.rollbackDeleteTransaction(
-                        self.jdbcClient, 'transaction, resourceType
-                    );
-                    if (rollbackResult is error) {
-                        log:printError(string `Rollback failed for ${resourceType}/${resourceId}: ${rollbackResult.message()}`);
-                    }
-                    return historyResult;
-                }
-            }
-
-            // Find references
-            log:printDebug(string `Finding references for ${resourceType}/${resourceId}`);
-            int[] referenceIds = check self.findSourceReferences(resourceType, resourceId);
-            log:printDebug(string `Found ${referenceIds.length()} reference(s) to delete for ${resourceType}/${resourceId}`);
-
-            // Delete references
-            error? refResult = utils:deleteReferences(self.jdbcClient, referenceIds, 'transaction);
-
-            if refResult is error {
-                log:printError(string `Failed to delete references for ${resourceType}/${resourceId}: ${refResult.message()}`);
-                error? rollbackResult = self.transactionHandler.rollbackDeleteTransaction(self.jdbcClient, 'transaction, resourceType);
-                if (rollbackResult is error) {
-                    log:printError(string `Rollback failed for ${resourceType}/${resourceId}: ${rollbackResult.message()}`);
-                }
-                return refResult;
-            }
-
-            // Delete main resource
-            log:printDebug(string `Deleting main ${resourceType}/${resourceId} record`);
-            
-            // Delete search parameters for this resource
-            jdbc:Client? jdbcConn = self.jdbcClient;
-            if jdbcConn is jdbc:Client {
-                log:printDebug(string `Deleting search parameters for ${resourceType}/${resourceId}`);
-                error? deleteSearchResult = utils:deleteSearchParametersForResource(jdbcConn, resourceType, resourceId);
-                if deleteSearchResult is error {
-                    log:printError(string `Failed to delete search parameters for ${resourceType}/${resourceId}: ${deleteSearchResult.message()}`);
-                    // Continue with delete even if search param cleanup fails
-                    log:printWarn(string `Continuing with delete despite search parameter cleanup failure`);
-                }
-            }
-            
-            // Special handling for SearchParameter resources - remove from expressions table
-            if resourceType == "SearchParameter" {
-                log:printDebug(string `Removing SearchParameter/${resourceId} from SEARCH_PARAM_RES_EXPRESSIONS`);
-                error? syncResult = utils:removeSearchParameterById(self.jdbcClient, resourceId);
-                if syncResult is error {
-                    log:printError(string `Failed to remove SearchParameter/${resourceId} from expressions: ${syncResult.message()}`);
-                    // Continue with delete even if sync fails (log warning)
-                    log:printWarn(string `Continuing with delete despite expression cleanup failure`);
-                } else {
-                    log:printInfo(string `Successfully removed SearchParameter/${resourceId} from expressions table`);
-                }
-            }
-            
-            error? deleteResult = utils:deleteResource(self.jdbcClient, resourceType, resourceId);
-
-            if deleteResult is error {
-                log:printError(string `Failed to delete main resource ${resourceType}/${resourceId}: ${deleteResult.message()}`);
-                error? rollbackResult = self.transactionHandler.rollbackDeleteTransaction(self.jdbcClient, 'transaction, resourceType);
-                if (rollbackResult is error) {
-                    log:printError(string `Rollback failed for ${resourceType}/${resourceId}: ${rollbackResult.message()}`);
-                }
-                return deleteResult;
-            }
-
-            // Remove from RESOURCE_TABLE so cascaded REFERENCES rows (target side)
-            // pointing to this resource are also cleaned up via ON DELETE CASCADE.
-            error? rtResult = utils:deleteFromResourceTable(self.jdbcClient, resourceType, resourceId);
-            if rtResult is error {
-                // Non-fatal: log the error but continue — main resource is already gone
-                log:printWarn(string `Failed to remove ${resourceType}/${resourceId} from RESOURCE_TABLE: ${rtResult.message()}`);
-            }
-
-            // Commit Transaction
-            log:printDebug(string `Committing delete transaction for ${resourceType}/${resourceId}`);
-            self.transactionHandler.commitTransaction('transaction, resourceType, resourceId);
-
-            log:printInfo(string `Successfully deleted ${resourceType}/${resourceId}`);
-            return true;
-
+        boolean result;
+        transaction {
+            result = check self.persistDelete(resourceType, resourceId);
+            check commit;
         } on fail error e {
             log:printError(string `Delete transaction failed for ${resourceType}/${resourceId}: ${e.message()}`);
-            error? rollbackResult = self.transactionHandler.rollbackDeleteTransaction(self.jdbcClient, 'transaction, resourceType);
-            if (rollbackResult is error) {
-                log:printError(string `Rollback failed during delete transaction cleanup for ${resourceType}: ${rollbackResult.message()}`);
-            }
             return e;
         }
+        return result;
     }
 
-    // Check if resource exists
-    private isolated function checkResourceExists(string resourceType, string resourceId) returns boolean|error {
-        return utils:resourceExists(self.jdbcClient, resourceType, resourceId);
-    }
-
-    // Find all references where this resource is the SOURCE
-    private isolated function findSourceReferences(string resourceType, string resourceId) returns int[]|error {
-
-        jdbc:Client? jdbcConn = self.jdbcClient;
-        if jdbcConn is () {
-            return error("JDBC client not initialized");
+    // Core delete pipeline. Callable from inside an outer transaction (Bundle
+    // handler / Phase 5).
+    public isolated function persistDelete(string resourceType, string resourceId) returns boolean|error {
+        // Check if resource exists
+        boolean exists = check utils:resourceExists(self.jdbcClient, resourceType, resourceId);
+        if !exists {
+            log:printWarn(string `Delete attempted on non-existent resource: ${resourceType}/${resourceId}`);
+            return error(string `${resourceType}/${resourceId} not found`);
         }
 
-        string sqlQuery = string `SELECT "ID" FROM "REFERENCES" WHERE "SOURCE_RESOURCE_TYPE" = '${utils:escapeSql(resourceType)}' AND "SOURCE_RESOURCE_ID" = '${utils:escapeSql(resourceId)}'`;
-        sql:ParameterizedQuery query = new utils:RawSQLQuery(sqlQuery);
+        // Read the current row so we can write it to RESOURCE_HISTORY before
+        // deleting. Used purely for the history snapshot now — no longer for
+        // rollback (the JDBC transaction handles that).
+        record {|anydata...;|} snapshot = check self.fetchResourceForHistory(resourceType, resourceId);
 
-        stream<record {|int ID;|}, sql:Error?> resultStream = jdbcConn->query(query);
+        int versionId = check int:fromString(snapshot.get("VERSION_ID").toString());
+        log:printDebug(string `Saving version ${versionId} of ${resourceType}/${resourceId} to history before deletion`);
+        check self.historyHandler.saveToHistory(resourceType, resourceId, snapshot, "DELETE");
 
-        record {|int ID;|}[] results = check from var result in resultStream
-            select result;
+        // Bulk-delete outgoing references in one statement.
+        utils:TransactionContext refCtx = utils:newTransactionContext();
+        refCtx.mainResourceId = resourceId;
+        check utils:deleteReferencesBySource(self.jdbcClient, resourceType, resourceId, refCtx);
 
-        int[] referenceIds = from var ref in results
-            select ref.ID;
+        // Delete search parameters for this resource. Non-fatal: drift in the
+        // search-param side tables is recoverable, but a failed primary delete
+        // must roll the whole transaction back — so search-param failures are
+        // only logged.
+        jdbc:Client? jdbcConn = self.jdbcClient;
+        if jdbcConn is jdbc:Client {
+            error? deleteSearchResult = utils:deleteSearchParametersForResource(jdbcConn, resourceType, resourceId);
+            if deleteSearchResult is error {
+                log:printWarn(string `Failed to delete search parameters for ${resourceType}/${resourceId}: ${deleteSearchResult.message()} (continuing)`);
+            }
+        }
 
-        return referenceIds;
+        // Special handling for SearchParameter resources - remove from expressions table
+        if resourceType == "SearchParameter" {
+            error? syncResult = utils:removeSearchParameterById(self.jdbcClient, resourceId);
+            if syncResult is error {
+                log:printWarn(string `Failed to remove SearchParameter/${resourceId} from expressions: ${syncResult.message()} (continuing)`);
+            } else {
+                log:printInfo(string `Successfully removed SearchParameter/${resourceId} from expressions table`);
+            }
+        }
+
+        // Delete the main resource row.
+        check utils:deleteResource(self.jdbcClient, resourceType, resourceId);
+
+        // Remove from RESOURCE_TABLE — ON DELETE CASCADE on REFERENCES
+        // cleans up rows pointing TO this resource.
+        error? rtResult = utils:deleteFromResourceTable(self.jdbcClient, resourceType, resourceId);
+        if rtResult is error {
+            log:printWarn(string `Failed to remove ${resourceType}/${resourceId} from RESOURCE_TABLE: ${rtResult.message()} (non-fatal)`);
+        }
+
+        // WORK.md §6 Phase 10: tombstone the row in FHIR_RESOURCE_INDEX so
+        // downstream cross-type history feeds can observe the deletion.
+        // PG-only; non-fatal.
+        error? friResult = utils:markFhirResourceIndexDeleted(self.jdbcClient, resourceType, resourceId);
+        if friResult is error {
+            log:printWarn(string `Failed to mark FHIR_RESOURCE_INDEX deleted for ${resourceType}/${resourceId}: ${friResult.message()} (non-fatal)`);
+        }
+
+        log:printInfo(string `Successfully deleted ${resourceType}/${resourceId}`);
+        return true;
     }
 
-    // Add backup methods to DeleteHandler
-    private isolated function backupResource(string resourceType, string resourceId) returns record {|anydata...;|}|error {
+    // Read the row (with all columns) so we can write it to RESOURCE_HISTORY.
+    private isolated function fetchResourceForHistory(string resourceType, string resourceId) returns record {|anydata...;|}|error {
 
         jdbc:Client? jdbcConn = self.jdbcClient;
         if jdbcConn is () {
@@ -182,27 +119,9 @@ public class DeleteHandler {
             select result;
 
         if results.length() == 0 {
-            return error(string `${resourceType}/${resourceId} not found for backup`);
+            return error(string `${resourceType}/${resourceId} not found for history snapshot`);
         }
 
         return results[0];
-    }
-
-    private isolated function backupReferences(string resourceType, string resourceId) returns record {|anydata...;|}[]|error {
-
-        jdbc:Client? jdbcConn = self.jdbcClient;
-        if jdbcConn is () {
-            return error("JDBC client not initialized");
-        }
-
-        string sqlQuery = string `SELECT * FROM "REFERENCES" WHERE "SOURCE_RESOURCE_TYPE" = '${utils:escapeSql(resourceType)}' AND "SOURCE_RESOURCE_ID" = '${utils:escapeSql(resourceId)}'`;
-        sql:ParameterizedQuery query = new utils:RawSQLQuery(sqlQuery);
-
-        stream<record {|anydata...;|}, sql:Error?> resultStream = jdbcConn->query(query);
-
-        record {|anydata...;|}[] results = check from var ref in resultStream
-            select ref;
-
-        return results;
     }
 }

--- a/miscellaneous/fhir-server/modules/handlers/history_handler.bal
+++ b/miscellaneous/fhir-server/modules/handlers/history_handler.bal
@@ -8,11 +8,9 @@ import ballerinax/java.jdbc;
 // Handler for managing resource version history
 public class HistoryHandler {
     private final jdbc:Client? jdbcClient;
-    private utils:TransactionHandler transactionHandler;
 
     public isolated function init(jdbc:Client? jdbcClient = ()) {
         self.jdbcClient = jdbcClient;
-        self.transactionHandler = new utils:TransactionHandler();
     }
 
     // Save current version to history before update/delete

--- a/miscellaneous/fhir-server/modules/handlers/update_handler.bal
+++ b/miscellaneous/fhir-server/modules/handlers/update_handler.bal
@@ -7,321 +7,179 @@ import ballerinax/java.jdbc;
 
 public class UpdateHandler {
     private mappers:UpdateMapper updateMapper;
-    private utils:TransactionHandler transactionHandler;
     private HistoryHandler historyHandler;
     private final jdbc:Client? jdbcClient;
 
     public isolated function init(jdbc:Client? jdbcClient = ()) {
         self.jdbcClient = jdbcClient;
         self.updateMapper = new mappers:UpdateMapper(jdbcClient);
-        self.transactionHandler = new utils:TransactionHandler();
         self.historyHandler = new HistoryHandler(jdbcClient);
     }
 
-    // Main function for PUT (full update)
+    // Public entry point for PUT (full update).
+    //
+    // WORK.md §5.1 / Phase 3: a real Ballerina `transaction { }` block now
+    // makes the multi-step update atomic at the JDBC layer. The previous
+    // application-level backup/restore plumbing is gone; on any failure the
+    // JDBC driver rolls back automatically.
     public isolated function updateResourceWithTransaction(string resourceType, string resourceId, json resourceJson) returns string|error {
-
-        // Begin transaction
-        utils:TransactionContext 'transaction = self.transactionHandler.beginTransaction();
-        'transaction.mainResourceId = resourceId;
-
-        do {
-            // Get JDBC client
-            jdbc:Client? jdbcConn = self.jdbcClient;
-            if jdbcConn is () {
-                return error("JDBC client not initialized");
-            }
-
-            // Check if resource exists
-            log:printDebug(string `Checking if ${resourceType}/${resourceId} exists`);
-            boolean exists = check self.checkResourceExists(resourceType, resourceId);
-
-            if !exists {
-                log:printWarn(string `Update attempted on non-existent resource: ${resourceType}/${resourceId}`);
-                return error(string `${resourceType}/${resourceId} not found`);
-            }
-
-            // Backup existing resource (for rollback)
-            log:printDebug(string `Backing up existing ${resourceType}/${resourceId}`);
-            record {|anydata...;|} backup = check self.backupResource(resourceType, resourceId);
-            'transaction.backupResource = backup;
-
-            // Delete old references (they will be recreated)
-            log:printDebug(string `Deleting old references for ${resourceType}/${resourceId}`);
-            int[] oldReferenceIds = check self.findSourceReferences(resourceType, resourceId);
-            error? deleteRefsResult = utils:deleteReferences(self.jdbcClient, oldReferenceIds, 'transaction);
-
-            if deleteRefsResult is error {
-                log:printError(string `Failed to delete old references for ${resourceType}/${resourceId}: ${deleteRefsResult.message()}`);
-                error? rollbackResult = self.transactionHandler.rollbackUpdateTransaction(
-                    self.jdbcClient, 'transaction, resourceType
-                );
-                if (rollbackResult is error) {
-                    log:printError(string `Rollback failed for ${resourceType}/${resourceId}: ${rollbackResult.message()}`);
-                }
-                return deleteRefsResult;
-            }
-
-            // Get current VERSION_ID and increment it
-            int currentVersion = check self.getCurrentVersionFromBackup(backup, resourceType);
-            int newVersion = currentVersion + 1;
-
-            // Map updated resource to update model
-            log:printDebug(string `Mapping updated ${resourceType} to model (version ${newVersion})`);
-            record {|anydata...;|}|error? updateModel = self.updateMapper.mapToUpdateModel(jdbcConn, resourceType, resourceJson, newVersion);
-
-            if updateModel is () || updateModel is error {
-                log:printError(string `Failed to map update model for ${resourceType}/${resourceId}: ${updateModel is error ? updateModel.message() : "mapper returned null"}`);
-                error? rollbackResult = self.transactionHandler.rollbackUpdateTransaction(
-                    self.jdbcClient, 'transaction, resourceType
-                );
-                if (rollbackResult is error) {
-                    log:printError(string `Rollback failed for ${resourceType}/${resourceId}: ${rollbackResult.message()}`);
-                }
-                return updateModel is error ? updateModel : error("Failed to create update model");
-            }
-
-            // Get extracted references after mapping
-            json[] references = self.updateMapper.getReferences();
-
-            // Update main resource
-            // Note: reference existence is enforced by the DB FK on RESOURCE_TABLE — no app-level SELECT needed.
-            log:printDebug(string `Updating main ${resourceType}/${resourceId} record`);
-            error? updateResult = self.updateMainResource(resourceType, resourceId, updateModel);
-
-            if updateResult is error {
-                log:printError(string `Failed to update main resource ${resourceType}/${resourceId}: ${updateResult.message()}`);
-                error? rollbackResult = self.transactionHandler.rollbackUpdateTransaction(
-                    self.jdbcClient, 'transaction, resourceType
-                );
-                if (rollbackResult is error) {
-                    log:printError(string `Rollback failed for ${resourceType}/${resourceId}: ${rollbackResult.message()}`);
-                }
-                return updateResult;
-            }
-
-            // Special handling for SearchParameter resources - sync to expressions table
-            if resourceType == "SearchParameter" {
-                log:printDebug(string `Syncing updated SearchParameter/${resourceId} to SEARCH_PARAM_RES_EXPRESSIONS`);
-                error? syncResult = utils:syncSearchParameterToExpressions(self.jdbcClient, resourceJson);
-                if syncResult is error {
-                    log:printError(string `Failed to sync SearchParameter/${resourceId}: ${syncResult.message()}`);
-                    error? rollbackResult = self.transactionHandler.rollbackUpdateTransaction(
-                        self.jdbcClient, 'transaction, resourceType
-                    );
-                    if (rollbackResult is error) {
-                        log:printError(string `Rollback failed for ${resourceType}/${resourceId}: ${rollbackResult.message()}`);
-                    }
-                    return syncResult;
-                }
-                log:printInfo(string `Successfully synced updated SearchParameter/${resourceId} to expressions table`);
-            }
-
-            // Save new version to history after successful update
-            log:printDebug(string `Saving new version of ${resourceType}/${resourceId} to history`);
-            error? historyResult = self.historyHandler.saveToHistory(resourceType, resourceId, updateModel, "PUT");
-            if historyResult is error {
-                log:printError(string `Failed to save history for ${resourceType}/${resourceId}: ${historyResult.message()}`);
-                error? rollbackResult = self.transactionHandler.rollbackUpdateTransaction(
-                    self.jdbcClient, 'transaction, resourceType
-                );
-                if (rollbackResult is error) {
-                    log:printError(string `Rollback failed for ${resourceType}/${resourceId}: ${rollbackResult.message()}`);
-                }
-                return historyResult;
-            }
-
-            // Update search parameters for indexed searching
-            log:printDebug(string `Updating search parameters for ${resourceType}/${resourceId}`);
-            error? updateSearchResult = utils:updateSearchParametersForResource(jdbcConn, resourceType, resourceId, resourceJson);
-            if updateSearchResult is error {
-                log:printError(string `Failed to update search parameters for ${resourceType}/${resourceId}: ${updateSearchResult.message()}`);
-                error? rollbackResult = self.transactionHandler.rollbackUpdateTransaction(
-                    self.jdbcClient, 'transaction, resourceType
-                );
-                if (rollbackResult is error) {
-                    log:printError(string `Rollback failed for ${resourceType}/${resourceId}: ${rollbackResult.message()}`);
-                }
-                return updateSearchResult;
-            }
-
-            // Save new references
-            log:printDebug(string `Saving new references for ${resourceType}/${resourceId}`);
-            error? refResult = utils:saveReferences(self.jdbcClient, references, resourceType, resourceId, 'transaction);
-
-            if refResult is error {
-                log:printError(string `Failed to save references for ${resourceType}/${resourceId}: ${refResult.message()}`);
-                error? rollbackResult = self.transactionHandler.rollbackUpdateTransaction(
-                    self.jdbcClient, 'transaction, resourceType
-                );
-                if (rollbackResult is error) {
-                    log:printError(string `Rollback failed for ${resourceType}/${resourceId}: ${rollbackResult.message()}`);
-                }
-                string refMsg = refResult.message();
-                if refMsg.includes("violates foreign key constraint") || refMsg.includes("FK_REFERENCES_TARGET") {
-                    return error(string `Unresolved reference: one or more TARGET resources referenced by ${resourceType}/${resourceId} do not exist. Ensure all referenced resources are created first.`);
-                }
-                return refResult;
-            }
-
-            // Commit transaction
-            log:printDebug(string `Committing update transaction for ${resourceType}/${resourceId}`);
-            self.transactionHandler.commitTransaction('transaction, resourceType, resourceId);
-
-            log:printDebug(string `Successfully updated ${resourceType}/${resourceId}`);
-            return resourceId;
-
+        string result;
+        transaction {
+            result = check self.persistUpdate(resourceType, resourceId, resourceJson);
+            check commit;
         } on fail error e {
             log:printError(string `Update transaction failed for ${resourceType}/${resourceId}: ${e.message()}`);
-            error? rollbackResult = self.transactionHandler.rollbackUpdateTransaction(
-                self.jdbcClient, 'transaction, resourceType
-            );
-            if (rollbackResult is error) {
-                log:printError(string `Rollback failed during update transaction cleanup for ${resourceType}/${resourceId}: ${rollbackResult.message()}`);
-            }
             return e;
         }
+        return result;
     }
 
-    // Main function for PATCH (partial update) with transaction support
+    // Public entry point for PATCH.
     public isolated function patchResourceWithTransaction(string resourceType, string resourceId, json patchJson) returns json|error {
-        // Get JDBC client
-        jdbc:Client? jdbcConn = self.jdbcClient;
-        if jdbcConn is () {
-            return error("JDBC client not initialized");
-        }
-
-        // Begin transaction
-        utils:TransactionContext 'transaction = self.transactionHandler.beginTransaction();
-        'transaction.mainResourceId = resourceId;
-
-        do {
-            // Check if resource exists and get current data
-            log:printDebug(string `Fetching existing ${resourceType}/${resourceId}`);
-            json existingResource = check self.getResourceAsJson(resourceType, resourceId);
-
-            // Backup for rollback
-            log:printDebug(string `Backing up existing resource`);
-            record {|anydata...;|} backup = check self.backupResource(resourceType, resourceId);
-            'transaction.backupResource = backup;
-
-            // Apply patch to existing resource
-            log:printDebug(string `Applying patch to ${resourceType}/${resourceId}`);
-            json mergedResource = check self.applyPatch(existingResource, patchJson);
-
-            // Delete old references
-            log:printDebug(string `Deleting old references`);
-            int[] oldReferenceIds = check self.findSourceReferences(resourceType, resourceId);
-            error? deleteRefsResult = utils:deleteReferences(self.jdbcClient, oldReferenceIds, 'transaction);
-
-            if deleteRefsResult is error {
-                log:printError(string `Failed to delete old references for ${resourceType}/${resourceId}: ${deleteRefsResult.message()}`);
-                error? rollbackResult = self.transactionHandler.rollbackUpdateTransaction(self.jdbcClient, 'transaction, resourceType);
-                if (rollbackResult is error) {
-                    log:printError(string `Rollback failed for ${resourceType}/${resourceId}: ${rollbackResult.message()}`);
-                }
-                return deleteRefsResult;
-            }
-
-            // Map merged resource to update model
-            log:printDebug(string `Mapping patched resource to model`);
-            record {|anydata...;|}|error? updateModel = self.updateMapper.mapToUpdateModel(jdbcConn, resourceType, mergedResource);
-
-            if updateModel is () || updateModel is error {
-                log:printError(string `Failed to map patched resource for ${resourceType}/${resourceId}: ${updateModel is error ? updateModel.message() : "mapper returned null"}`);
-                error? rollbackResult = self.transactionHandler.rollbackUpdateTransaction(self.jdbcClient, 'transaction, resourceType);
-                if (rollbackResult is error) {
-                    log:printError(string `Rollback failed for ${resourceType}/${resourceId}: ${rollbackResult.message()}`);
-                }
-                return updateModel is error ? updateModel : error("Failed to create update model");
-            }
-
-            // Get extracted references after mapping
-            json[] references = self.updateMapper.getReferences();
-
-            // Update main resource
-            // Note: reference existence is enforced by the DB FK on RESOURCE_TABLE — no app-level SELECT needed.
-            log:printDebug(string `Updating main resource`);
-            error? updateResult = self.updateMainResource(resourceType, resourceId, updateModel);
-
-            if updateResult is error {
-                log:printError(string `Failed to update main resource ${resourceType}/${resourceId}: ${updateResult.message()}`);
-                error? rollbackResult = self.transactionHandler.rollbackUpdateTransaction(
-                    self.jdbcClient, 'transaction, resourceType
-                );
-                if (rollbackResult is error) {
-                    log:printError(string `Rollback failed for ${resourceType}/${resourceId}: ${rollbackResult.message()}`);
-                }
-                return updateResult;
-            }
-
-            // Save new references
-            log:printDebug(string `Saving new references`);
-            error? refResult = utils:saveReferences(self.jdbcClient, references, resourceType, resourceId, 'transaction);
-
-            if refResult is error {
-                log:printError(string `Failed to save references for ${resourceType}/${resourceId}: ${refResult.message()}`);
-                error? rollbackResult = self.transactionHandler.rollbackUpdateTransaction(
-                    self.jdbcClient, 'transaction, resourceType);
-                if (rollbackResult is error) {
-                    log:printError(string `Rollback failed for ${resourceType}/${resourceId}: ${rollbackResult.message()}`);
-                }
-                string refMsg = refResult.message();
-                if refMsg.includes("violates foreign key constraint") || refMsg.includes("FK_REFERENCES_TARGET") {
-                    return error(string `Unresolved reference: one or more TARGET resources referenced by ${resourceType}/${resourceId} do not exist. Ensure all referenced resources are created first.`);
-                }
-                return refResult;
-            }
-
-            // Commit transaction
-            log:printDebug(string `Committing patch transaction for ${resourceType}/${resourceId}`);
-            self.transactionHandler.commitTransaction('transaction, resourceType, resourceId);
-
-            log:printDebug(string `Successfully patched ${resourceType}/${resourceId}`);
-            return mergedResource;
-
+        json result;
+        transaction {
+            result = check self.persistPatch(resourceType, resourceId, patchJson);
+            check commit;
         } on fail error e {
             log:printError(string `Patch transaction failed for ${resourceType}/${resourceId}: ${e.message()}`);
-            error? rollbackResult = self.transactionHandler.rollbackUpdateTransaction(
-                self.jdbcClient, 'transaction, resourceType
-            );
-            if (rollbackResult is error) {
-                log:printError(string `Rollback failed during patch transaction cleanup for ${resourceType}/${resourceId}: ${rollbackResult.message()}`);
-            }
             return e;
         }
+        return result;
     }
 
-    // Check if resource exists
-    private isolated function checkResourceExists(string resourceType, string resourceId) returns boolean|error {
-        return utils:resourceExists(self.jdbcClient, resourceType, resourceId);
-    }
+    // Core PUT pipeline. Callable from inside an outer transaction (Bundle
+    // handler / Phase 5).
+    public isolated function persistUpdate(string resourceType, string resourceId, json resourceJson) returns string|error {
+        jdbc:Client jdbcConn = check utils:getValidatedJdbcClient(self.jdbcClient);
 
-    // Backup resource for rollback
-    private isolated function backupResource(string resourceType,
-            string resourceId) returns record {|anydata...;|}|error {
-
-        jdbc:Client? jdbcConn = self.jdbcClient;
-        if jdbcConn is () {
-            return error("JDBC client not initialized");
+        // Check if resource exists
+        boolean exists = check utils:resourceExists(self.jdbcClient, resourceType, resourceId);
+        if !exists {
+            log:printWarn(string `Update attempted on non-existent resource: ${resourceType}/${resourceId}`);
+            return error(string `${resourceType}/${resourceId} not found`);
         }
+
+        // We need the current VERSION_ID to write the next one. With real
+        // DB transactions there's no rollback need, so we only fetch the
+        // single column instead of the whole row.
+        int currentVersion = check self.fetchCurrentVersion(resourceType, resourceId);
+        int newVersion = currentVersion + 1;
+
+        // Bulk-delete old references (single statement, WORK.md §5.2).
+        utils:TransactionContext refCtx = utils:newTransactionContext();
+        refCtx.mainResourceId = resourceId;
+        check utils:deleteReferencesBySource(self.jdbcClient, resourceType, resourceId, refCtx);
+
+        // Map updated resource to update model
+        log:printDebug(string `Mapping updated ${resourceType} to model (version ${newVersion})`);
+        record {|anydata...;|}|error? updateModel = self.updateMapper.mapToUpdateModel(jdbcConn, resourceType, resourceJson, newVersion);
+        if updateModel is () || updateModel is error {
+            return updateModel is error ? updateModel : error("Failed to create update model");
+        }
+
+        json[] references = self.updateMapper.getReferences();
+
+        // Update main resource
+        check self.updateMainResource(resourceType, resourceId, updateModel);
+
+        // WORK.md §6 Phase 10: refresh the cross-type FHIR_RESOURCE_INDEX
+        // feed. PG-only; non-fatal.
+        error? friResult = utils:upsertFhirResourceIndex(self.jdbcClient, resourceType, resourceId, newVersion);
+        if friResult is error {
+            log:printWarn(string `Failed to upsert FHIR_RESOURCE_INDEX for ${resourceType}/${resourceId}: ${friResult.message()} (non-fatal)`);
+        }
+
+        if resourceType == "SearchParameter" {
+            check utils:syncSearchParameterToExpressions(self.jdbcClient, resourceJson);
+            log:printInfo(string `Successfully synced updated SearchParameter/${resourceId} to expressions table`);
+        }
+
+        // Save new version to history
+        check self.historyHandler.saveToHistory(resourceType, resourceId, updateModel, "PUT");
+
+        // Update search parameters for indexed searching
+        check utils:updateSearchParametersForResource(jdbcConn, resourceType, resourceId, resourceJson);
+
+        // Save new references — translate FK violation to a 422-shaped error.
+        error? refResult = utils:saveReferences(self.jdbcClient, references, resourceType, resourceId, refCtx);
+        if refResult is error {
+            string refMsg = refResult.message();
+            if refMsg.includes("violates foreign key constraint") || refMsg.includes("FK_REFERENCES_TARGET") {
+                return error(string `Unresolved reference: one or more TARGET resources referenced by ${resourceType}/${resourceId} do not exist. Ensure all referenced resources are created first.`);
+            }
+            return refResult;
+        }
+
+        log:printDebug(string `Successfully updated ${resourceType}/${resourceId}`);
+        return resourceId;
+    }
+
+    // Core PATCH pipeline. Callable from inside an outer transaction.
+    public isolated function persistPatch(string resourceType, string resourceId, json patchJson) returns json|error {
+        jdbc:Client jdbcConn = check utils:getValidatedJdbcClient(self.jdbcClient);
+
+        // Fetch existing resource (PATCH needs the JSON to merge against)
+        json existingResource = check self.getResourceAsJson(resourceType, resourceId);
+
+        // Apply patch to existing resource
+        json mergedResource = check self.applyPatch(existingResource, patchJson);
+
+        // Bulk-delete old references
+        utils:TransactionContext refCtx = utils:newTransactionContext();
+        refCtx.mainResourceId = resourceId;
+        check utils:deleteReferencesBySource(self.jdbcClient, resourceType, resourceId, refCtx);
+
+        // Map merged resource to update model
+        record {|anydata...;|}|error? updateModel = self.updateMapper.mapToUpdateModel(jdbcConn, resourceType, mergedResource);
+        if updateModel is () || updateModel is error {
+            return updateModel is error ? updateModel : error("Failed to create update model");
+        }
+
+        json[] references = self.updateMapper.getReferences();
+
+        check self.updateMainResource(resourceType, resourceId, updateModel);
+
+        // WORK.md §6 Phase 10: refresh FHIR_RESOURCE_INDEX with the version
+        // the mapper actually wrote (defaults to 2 if mapper didn't set it).
+        int patchedVersion = 2;
+        anydata patchedVersionField = updateModel["VERSION_ID"];
+        if patchedVersionField is int {
+            patchedVersion = patchedVersionField;
+        }
+        error? friResult = utils:upsertFhirResourceIndex(self.jdbcClient, resourceType, resourceId, patchedVersion);
+        if friResult is error {
+            log:printWarn(string `Failed to upsert FHIR_RESOURCE_INDEX for ${resourceType}/${resourceId}: ${friResult.message()} (non-fatal)`);
+        }
+
+        error? refResult = utils:saveReferences(self.jdbcClient, references, resourceType, resourceId, refCtx);
+        if refResult is error {
+            string refMsg = refResult.message();
+            if refMsg.includes("violates foreign key constraint") || refMsg.includes("FK_REFERENCES_TARGET") {
+                return error(string `Unresolved reference: one or more TARGET resources referenced by ${resourceType}/${resourceId} do not exist. Ensure all referenced resources are created first.`);
+            }
+            return refResult;
+        }
+
+        log:printDebug(string `Successfully patched ${resourceType}/${resourceId}`);
+        return mergedResource;
+    }
+
+    // Fetch the current VERSION_ID for a resource. Replaces the prior
+    // SELECT * "backup" — we only need the version, not the whole row.
+    private isolated function fetchCurrentVersion(string resourceType, string resourceId) returns int|error {
+        jdbc:Client jdbcConn = check utils:getValidatedJdbcClient(self.jdbcClient);
 
         string tableName = utils:getTableName(resourceType);
         string primaryKey = utils:getPrimaryKeyColumn(resourceType);
 
-        string sqlQuery = string `SELECT * FROM "${tableName}" WHERE "${primaryKey}" = '${utils:escapeSql(resourceId)}'`;
+        string sqlQuery = string `SELECT "VERSION_ID" FROM "${tableName}" WHERE "${primaryKey}" = '${utils:escapeSql(resourceId)}'`;
         sql:ParameterizedQuery query = new utils:RawSQLQuery(sqlQuery);
 
-        stream<record {|anydata...;|}, sql:Error?> resultStream = jdbcConn->query(query);
-
-        record {|anydata...;|}[] results = check from var result in resultStream
-            select result;
-
-        if results.length() == 0 {
-            return error(string `${resourceType}/${resourceId} not found for backup`);
+        int|sql:Error result = jdbcConn->queryRow(query);
+        if result is sql:Error {
+            return error(string `Failed to read VERSION_ID for ${resourceType}/${resourceId}: ${result.message()}`);
         }
-
-        return results[0];
+        return result;
     }
 
     // Get resource as JSON (for PATCH operations)
@@ -391,28 +249,6 @@ public class UpdateHandler {
         return mergedMap;
     }
 
-    // Find source references
-    private isolated function findSourceReferences(string resourceType, string resourceId) returns int[]|error {
-
-        jdbc:Client? jdbcConn = self.jdbcClient;
-        if jdbcConn is () {
-            return error("JDBC client not initialized");
-        }
-
-        string sqlQuery = string `SELECT "ID" FROM "REFERENCES" WHERE "SOURCE_RESOURCE_TYPE" = '${utils:escapeSql(resourceType)}' AND "SOURCE_RESOURCE_ID" = '${utils:escapeSql(resourceId)}'`;
-        sql:ParameterizedQuery query = new utils:RawSQLQuery(sqlQuery);
-
-        stream<record {|int ID;|}, sql:Error?> resultStream = jdbcConn->query(query);
-
-        record {|int ID;|}[] results = check from var result in resultStream
-            select result;
-
-        int[] referenceIds = from var ref in results
-            select ref.ID;
-
-        return referenceIds;
-    }
-
     private isolated function updateMainResource(string resourceType, string resourceId, record {|anydata...;|} updateModel) returns error? {
 
         jdbc:Client? jdbcConn = self.jdbcClient;
@@ -431,7 +267,7 @@ public class UpdateHandler {
             if key == "DATE" {
                 formattedValue = utils:formatDateValue(value);
             } else {
-                formattedValue = self.transactionHandler.formatValue(value);
+                formattedValue = utils:formatSqlValue(value);
             }
             setClauses.push(string `"${key}" = ${formattedValue}`);
         }
@@ -451,15 +287,5 @@ public class UpdateHandler {
         }
 
         return;
-    }
-
-    // Extract current VERSION_ID from backup
-    private isolated function getCurrentVersionFromBackup(record {|anydata...;|} backup, string resourceType) returns int|error {
-        // Generic extraction - all resource tables have VERSION_ID
-        anydata versionField = backup["VERSION_ID"];
-        if versionField is int {
-            return versionField;
-        }
-        return error(string `Could not extract VERSION_ID for ${resourceType}: field is ${versionField.toString()}`);
     }
 }

--- a/miscellaneous/fhir-server/modules/handlers/update_handler.bal
+++ b/miscellaneous/fhir-server/modules/handlers/update_handler.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina_fhir_server.mappers;
 import ballerina_fhir_server.utils;
 
@@ -16,12 +32,6 @@ public class UpdateHandler {
         self.historyHandler = new HistoryHandler(jdbcClient);
     }
 
-    // Public entry point for PUT (full update).
-    //
-    // WORK.md §5.1 / Phase 3: a real Ballerina `transaction { }` block now
-    // makes the multi-step update atomic at the JDBC layer. The previous
-    // application-level backup/restore plumbing is gone; on any failure the
-    // JDBC driver rolls back automatically.
     public isolated function updateResourceWithTransaction(string resourceType, string resourceId, json resourceJson) returns string|error {
         string result;
         transaction {
@@ -47,8 +57,6 @@ public class UpdateHandler {
         return result;
     }
 
-    // Core PUT pipeline. Callable from inside an outer transaction (Bundle
-    // handler / Phase 5).
     public isolated function persistUpdate(string resourceType, string resourceId, json resourceJson) returns string|error {
         jdbc:Client jdbcConn = check utils:getValidatedJdbcClient(self.jdbcClient);
 
@@ -59,18 +67,13 @@ public class UpdateHandler {
             return error(string `${resourceType}/${resourceId} not found`);
         }
 
-        // We need the current VERSION_ID to write the next one. With real
-        // DB transactions there's no rollback need, so we only fetch the
-        // single column instead of the whole row.
         int currentVersion = check self.fetchCurrentVersion(resourceType, resourceId);
         int newVersion = currentVersion + 1;
 
-        // Bulk-delete old references (single statement, WORK.md §5.2).
         utils:TransactionContext refCtx = utils:newTransactionContext();
         refCtx.mainResourceId = resourceId;
         check utils:deleteReferencesBySource(self.jdbcClient, resourceType, resourceId, refCtx);
 
-        // Map updated resource to update model
         log:printDebug(string `Mapping updated ${resourceType} to model (version ${newVersion})`);
         record {|anydata...;|}|error? updateModel = self.updateMapper.mapToUpdateModel(jdbcConn, resourceType, resourceJson, newVersion);
         if updateModel is () || updateModel is error {
@@ -79,11 +82,8 @@ public class UpdateHandler {
 
         json[] references = self.updateMapper.getReferences();
 
-        // Update main resource
         check self.updateMainResource(resourceType, resourceId, updateModel);
 
-        // WORK.md §6 Phase 10: refresh the cross-type FHIR_RESOURCE_INDEX
-        // feed. PG-only; non-fatal.
         error? friResult = utils:upsertFhirResourceIndex(self.jdbcClient, resourceType, resourceId, newVersion);
         if friResult is error {
             log:printWarn(string `Failed to upsert FHIR_RESOURCE_INDEX for ${resourceType}/${resourceId}: ${friResult.message()} (non-fatal)`);
@@ -94,13 +94,10 @@ public class UpdateHandler {
             log:printInfo(string `Successfully synced updated SearchParameter/${resourceId} to expressions table`);
         }
 
-        // Save new version to history
         check self.historyHandler.saveToHistory(resourceType, resourceId, updateModel, "PUT");
 
-        // Update search parameters for indexed searching
         check utils:updateSearchParametersForResource(jdbcConn, resourceType, resourceId, resourceJson);
 
-        // Save new references — translate FK violation to a 422-shaped error.
         error? refResult = utils:saveReferences(self.jdbcClient, references, resourceType, resourceId, refCtx);
         if refResult is error {
             string refMsg = refResult.message();
@@ -114,22 +111,17 @@ public class UpdateHandler {
         return resourceId;
     }
 
-    // Core PATCH pipeline. Callable from inside an outer transaction.
     public isolated function persistPatch(string resourceType, string resourceId, json patchJson) returns json|error {
         jdbc:Client jdbcConn = check utils:getValidatedJdbcClient(self.jdbcClient);
 
-        // Fetch existing resource (PATCH needs the JSON to merge against)
         json existingResource = check self.getResourceAsJson(resourceType, resourceId);
 
-        // Apply patch to existing resource
         json mergedResource = check self.applyPatch(existingResource, patchJson);
 
-        // Bulk-delete old references
         utils:TransactionContext refCtx = utils:newTransactionContext();
         refCtx.mainResourceId = resourceId;
         check utils:deleteReferencesBySource(self.jdbcClient, resourceType, resourceId, refCtx);
 
-        // Map merged resource to update model
         record {|anydata...;|}|error? updateModel = self.updateMapper.mapToUpdateModel(jdbcConn, resourceType, mergedResource);
         if updateModel is () || updateModel is error {
             return updateModel is error ? updateModel : error("Failed to create update model");
@@ -139,8 +131,6 @@ public class UpdateHandler {
 
         check self.updateMainResource(resourceType, resourceId, updateModel);
 
-        // WORK.md §6 Phase 10: refresh FHIR_RESOURCE_INDEX with the version
-        // the mapper actually wrote (defaults to 2 if mapper didn't set it).
         int patchedVersion = 2;
         anydata patchedVersionField = updateModel["VERSION_ID"];
         if patchedVersionField is int {
@@ -164,8 +154,6 @@ public class UpdateHandler {
         return mergedResource;
     }
 
-    // Fetch the current VERSION_ID for a resource. Replaces the prior
-    // SELECT * "backup" — we only need the version, not the whole row.
     private isolated function fetchCurrentVersion(string resourceType, string resourceId) returns int|error {
         jdbc:Client jdbcConn = check utils:getValidatedJdbcClient(self.jdbcClient);
 
@@ -182,7 +170,6 @@ public class UpdateHandler {
         return result;
     }
 
-    // Get resource as JSON (for PATCH operations)
     private isolated function getResourceAsJson(string resourceType, string resourceId) returns json|error {
 
         jdbc:Client? jdbcConn = self.jdbcClient;
@@ -225,7 +212,6 @@ public class UpdateHandler {
         return resourceJson;
     }
 
-    // Apply JSON patch
     private isolated function applyPatch(json existing, json patch) returns json|error {
         if !(existing is map<json>) {
             return error(string `Existing resource is not a JSON object: ${existing.toString()}`);
@@ -238,10 +224,8 @@ public class UpdateHandler {
         map<json> existingMap = <map<json>>existing;
         map<json> patchMap = <map<json>>patch;
 
-        // Create a new map to hold merged values
         map<json> mergedMap = existingMap.clone();
 
-        // Patch values override existing values
         foreach var [key, value] in patchMap.entries() {
             mergedMap[key] = value;
         }
@@ -259,11 +243,9 @@ public class UpdateHandler {
         string tableName = utils:getTableName(resourceType);
         string primaryKey = utils:getPrimaryKeyColumn(resourceType);
 
-        // Build UPDATE SET clause dynamically from updateModel fields
         string[] setClauses = [];
         foreach var [key, value] in updateModel.entries() {
             string formattedValue;
-            // Use special formatting for DATE columns (date only, no time)
             if key == "DATE" {
                 formattedValue = utils:formatDateValue(value);
             } else {

--- a/miscellaneous/fhir-server/modules/handlers/update_handler.bal
+++ b/miscellaneous/fhir-server/modules/handlers/update_handler.bal
@@ -33,6 +33,7 @@ public class UpdateHandler {
     }
 
     public isolated function updateResourceWithTransaction(string resourceType, string resourceId, json resourceJson) returns string|error {
+        log:printInfo(string `Starting update transaction for ${resourceType}/${resourceId}`);
         string result;
         transaction {
             result = check self.persistUpdate(resourceType, resourceId, resourceJson);
@@ -46,6 +47,7 @@ public class UpdateHandler {
 
     // Public entry point for PATCH.
     public isolated function patchResourceWithTransaction(string resourceType, string resourceId, json patchJson) returns json|error {
+        log:printInfo(string `Starting patch transaction for ${resourceType}/${resourceId}`);
         json result;
         transaction {
             result = check self.persistPatch(resourceType, resourceId, patchJson);
@@ -140,6 +142,15 @@ public class UpdateHandler {
         if friResult is error {
             log:printWarn(string `Failed to upsert FHIR_RESOURCE_INDEX for ${resourceType}/${resourceId}: ${friResult.message()} (non-fatal)`);
         }
+
+        if resourceType == "SearchParameter" {
+            check utils:syncSearchParameterToExpressions(self.jdbcClient, mergedResource);
+            log:printInfo(string `Successfully synced patched SearchParameter/${resourceId} to expressions table`);
+        }
+
+        check self.historyHandler.saveToHistory(resourceType, resourceId, updateModel, "PATCH");
+
+        check utils:updateSearchParametersForResource(jdbcConn, resourceType, resourceId, mergedResource);
 
         error? refResult = utils:saveReferences(self.jdbcClient, references, resourceType, resourceId, refCtx);
         if refResult is error {

--- a/miscellaneous/fhir-server/modules/mappers/read_mapper.bal
+++ b/miscellaneous/fhir-server/modules/mappers/read_mapper.bal
@@ -317,7 +317,7 @@ public class ReadMapper {
 
             // Handle other unsupported FHIR control parameters that start with _
             if paramName.startsWith("_") && paramName != "_lastUpdated" && paramName != "_id" {
-                return error(string `Unsupported search parameter: ${paramName}. Only common resource parameters of _id, _lastUpdated, _profile, _include, _revinclude, and _total are currently supported.`);
+                return error(string `Unsupported search parameter: ${paramName}. Only common resource parameters of _id, _lastUpdated, _profile, _include, _revinclude, _total, _count, _summary, and _elements are currently supported.`);
             }
 
             string operator = "=";
@@ -524,7 +524,9 @@ public class ReadMapper {
             // Filtered estimates would need EXPLAIN parsing — defer.
             sql:ParameterizedQuery cQuery = `SELECT reltuples::BIGINT AS "COUNT" FROM pg_class WHERE relname = ${tableName}`;
             record {|int COUNT;|}? estResult = check jdbcClient->queryRow(cQuery);
-            if estResult != () {
+            // reltuples is -1 for never-analyzed tables and 0 for truncated tables;
+            // only surface a meaningful estimate.
+            if estResult != () && estResult.COUNT >= 0 {
                 totalCount = estResult.COUNT;
             }
         }
@@ -1267,6 +1269,7 @@ public class ReadMapper {
         if targetIds.length() == 0 {
             return [];
         }
+        log:printDebug(string `Batch reading ${targetIds.length()} resources of type: ${targetType}`);
         string tableName = utils:getTableName(targetType);
         string primaryKey = utils:getPrimaryKeyColumn(targetType);
 

--- a/miscellaneous/fhir-server/modules/mappers/read_mapper.bal
+++ b/miscellaneous/fhir-server/modules/mappers/read_mapper.bal
@@ -257,18 +257,29 @@ public class ReadMapper {
             }
         }
 
-        // Handle _profile parameter (search by meta.profile)
+        // Handle _profile parameter (search by meta.profile).
+        // PostgreSQL: use JSONB containment (@>) so the body GIN index serves
+        // the predicate (WORK.md §5.5.1). H2 falls back to LIKE since it has
+        // no JSONB / GIN.
+        string normalizedDbTypeForProfile = mapperUtils:dbType.toLowerAscii().trim();
+        boolean isPgForProfile = normalizedDbTypeForProfile == "postgresql" || normalizedDbTypeForProfile == "postgres";
         if queryParams.hasKey("_profile") {
             string[] profileValues = queryParams.get("_profile");
             if profileValues.length() > 0 {
                 string profileUrl = profileValues[0];
                 string sanitizedProfile = utils:escapeSql(profileUrl);
-                // Search for profile URL in the RESOURCE_JSON meta.profile array
-                // Format: "profile":["http://example.org/fhir/StructureDefinition/CustomPatient"]
-                if whereClause == "" {
-                    whereClause = string ` WHERE "RESOURCE_JSON" LIKE '%"profile":%"${sanitizedProfile}"%'`;
+                string profilePredicate;
+                if isPgForProfile {
+                    // {"meta":{"profile":["..."]}} — array containment is
+                    // semantic, hits IDX_<Type>TABLE_JSON_GIN.
+                    profilePredicate = string `"RESOURCE_JSON" @> '{"meta":{"profile":["${sanitizedProfile}"]}}'::jsonb`;
                 } else {
-                    whereClause = whereClause + string ` AND "RESOURCE_JSON" LIKE '%"profile":%"${sanitizedProfile}"%'`;
+                    profilePredicate = string `"RESOURCE_JSON" LIKE '%"profile":%"${sanitizedProfile}"%'`;
+                }
+                if whereClause == "" {
+                    whereClause = string ` WHERE ${profilePredicate}`;
+                } else {
+                    whereClause = whereClause + string ` AND ${profilePredicate}`;
                 }
             }
         }
@@ -297,21 +308,23 @@ public class ReadMapper {
                 continue;
             }
 
-            // Skip _count parameter (sent by default) and _include/_revinclude/_profile parameters (handled separately after main search)
-            if paramName == "_count" || paramName == "_include" || paramName == "_revinclude" || paramName == "_profile" {
+            // Skip control params handled outside the WHERE-clause loop:
+            //   _count, _include, _revinclude, _profile, _total, _summary, _elements
+            if paramName == "_count" || paramName == "_include" || paramName == "_revinclude"
+                    || paramName == "_profile" || paramName == "_total"
+                    || paramName == "_summary" || paramName == "_elements" {
                 continue;
             }
 
             // Handle other unsupported FHIR control parameters that start with _
             if paramName.startsWith("_") && paramName != "_lastUpdated" && paramName != "_id" {
-                return error(string `Unsupported search parameter: ${paramName}. Only common resource parameters of _id, _lastUpdated, _profile, _include, and _revinclude are currently supported.`);
+                return error(string `Unsupported search parameter: ${paramName}. Only common resource parameters of _id, _lastUpdated, _profile, _include, _revinclude, and _total are currently supported.`);
             }
 
             string operator = "=";
             string searchValue = paramValue;
             string? tokenSystem = ();
             string? tokenCode = ();
-            boolean tokenSystemEmpty = false;
 
             // Process token parameter (already detected above)
             // Token parameters support 4 formats per FHIR spec:
@@ -319,6 +332,10 @@ public class ReadMapper {
             // 2. [system]|[code]: Match both system and code
             // 3. |[code]: Match code where system is absent
             // 4. [system]|: Match system only, any code
+            // Note: case 1 vs case 3 (system-absent) are not distinguished —
+            // both produce a code-only predicate. JSONB @> can't express the
+            // "system must be absent" assertion concisely; the prior LIKE
+            // didn't enforce it either, so behavior is unchanged.
             if isTokenParam {
                 string[] tokenParts = regexp:split(re `\|`, paramValue);
                 if tokenParts.length() == 2 {
@@ -326,9 +343,8 @@ public class ReadMapper {
                     string codePart = tokenParts[1];
 
                     if systemPart == "" && codePart != "" {
-                        // Case 3: |[code] - code with no system
+                        // Case 3: |[code] - code with no system (best-effort: code-only)
                         tokenCode = codePart;
-                        tokenSystemEmpty = true;
                     } else if systemPart != "" && codePart == "" {
                         // Case 4: [system]| - system only, any code
                         tokenSystem = systemPart;
@@ -386,40 +402,67 @@ public class ReadMapper {
             }
 
             if columnName is string {
-                // For token parameters with system|code format
-                // Token columns contain JSON like [{"coding":[{"system":"...","code":"..."}]}]
+                // For token parameters with system|code format.
+                // PostgreSQL: use RESOURCE_JSON @> containment so the body GIN
+                // index (IDX_<Type>TABLE_JSON_GIN) serves the predicate in
+                // O(log N + matches). H2: keep the legacy LIKE on the
+                // denormalized column. WORK.md §5.5.2.
                 if isTokenParam {
                     string sanitizedSystem = tokenSystem is string ? utils:escapeSql(tokenSystem) : "";
                     string sanitizedCode = tokenCode is string ? utils:escapeSql(tokenCode) : "";
+                    string normalizedDbTypeForToken = mapperUtils:dbType.toLowerAscii().trim();
+                    boolean isPgForToken = normalizedDbTypeForToken == "postgresql" || normalizedDbTypeForToken == "postgres";
 
-                    if tokenSystem is string && tokenCode is string {
-                        // Case 2: [system]|[code] - Both system and code must match
-                        if whereClause == "" {
-                            whereClause = string ` WHERE (${columnName} LIKE '%"system":"${sanitizedSystem}"%' OR ${columnName} LIKE '%"system": "${sanitizedSystem}"%') AND (${columnName} LIKE '%"code":"${sanitizedCode}"%' OR ${columnName} LIKE '%"code": "${sanitizedCode}"%')`;
+                    // FHIR JSON path heuristic for the @> payload:
+                    //   identifier  → {identifier:[{system,value}]}  (array, "value" key)
+                    //   *           → {<param>:{coding:[{system,code}]}}  (CodeableConcept)
+                    // For unrecognized shapes the @> may not match; this is the
+                    // same correctness contract as the prior LIKE — both are
+                    // best-effort and don't honor every edge of the FHIR token
+                    // spec. The plan in WORK.md §5.7 will replace both with
+                    // typed SPIDX side tables.
+                    string jsonPath = paramName.toLowerAscii();
+                    boolean isIdentifierShape = jsonPath == "identifier";
+                    string codeKey = isIdentifierShape ? "value" : "code";
+
+                    string predicate;
+                    if isPgForToken {
+                        string innerObj;
+                        if tokenSystem is string && tokenCode is string {
+                            innerObj = string `{"system":"${sanitizedSystem}","${codeKey}":"${sanitizedCode}"}`;
+                        } else if tokenCode is string {
+                            innerObj = string `{"${codeKey}":"${sanitizedCode}"}`;
+                        } else if tokenSystem is string {
+                            innerObj = string `{"system":"${sanitizedSystem}"}`;
                         } else {
-                            whereClause = whereClause + string ` AND (${columnName} LIKE '%"system":"${sanitizedSystem}"%' OR ${columnName} LIKE '%"system": "${sanitizedSystem}"%') AND (${columnName} LIKE '%"code":"${sanitizedCode}"%' OR ${columnName} LIKE '%"code": "${sanitizedCode}"%')`;
+                            innerObj = "";
                         }
-                    } else if tokenCode is string && tokenSystemEmpty {
-                        // Case 3: |[code] - Code matches but system must be absent/null
-                        // This is complex - for simplicity, just search for code (limitation)
-                        if whereClause == "" {
-                            whereClause = string ` WHERE (${columnName} LIKE '%"code":"${sanitizedCode}"%' OR ${columnName} LIKE '%"code": "${sanitizedCode}"%')`;
+
+                        if innerObj == "" {
+                            predicate = "";
+                        } else if isIdentifierShape {
+                            predicate = string `"RESOURCE_JSON" @> '{"identifier":[${innerObj}]}'::jsonb`;
                         } else {
-                            whereClause = whereClause + string ` AND (${columnName} LIKE '%"code":"${sanitizedCode}"%' OR ${columnName} LIKE '%"code": "${sanitizedCode}"%')`;
+                            predicate = string `"RESOURCE_JSON" @> '{"${jsonPath}":{"coding":[${innerObj}]}}'::jsonb`;
                         }
-                    } else if tokenCode is string {
-                        // This shouldn't happen with current logic, but handle it
-                        if whereClause == "" {
-                            whereClause = string ` WHERE (${columnName} LIKE '%"code":"${sanitizedCode}"%' OR ${columnName} LIKE '%"code": "${sanitizedCode}"%')`;
+                    } else {
+                        // H2 fallback: original LIKE-on-denormalized-column logic.
+                        if tokenSystem is string && tokenCode is string {
+                            predicate = string `(${columnName} LIKE '%"system":"${sanitizedSystem}"%' OR ${columnName} LIKE '%"system": "${sanitizedSystem}"%') AND (${columnName} LIKE '%"${codeKey}":"${sanitizedCode}"%' OR ${columnName} LIKE '%"${codeKey}": "${sanitizedCode}"%')`;
+                        } else if tokenCode is string {
+                            predicate = string `(${columnName} LIKE '%"${codeKey}":"${sanitizedCode}"%' OR ${columnName} LIKE '%"${codeKey}": "${sanitizedCode}"%')`;
+                        } else if tokenSystem is string {
+                            predicate = string `("${columnName}" LIKE '%"system":"${sanitizedSystem}"%' OR "${columnName}" LIKE '%"system": "${sanitizedSystem}"%')`;
                         } else {
-                            whereClause = whereClause + string ` AND (${columnName} LIKE '%"code":"${sanitizedCode}"%' OR ${columnName} LIKE '%"code": "${sanitizedCode}"%')`;
+                            predicate = "";
                         }
-                    } else if tokenSystem is string {
-                        // Case 4: [system]| - System matches, any code
+                    }
+
+                    if predicate != "" {
                         if whereClause == "" {
-                            whereClause = string ` WHERE ("${columnName}" LIKE '%"system":"${sanitizedSystem}"%' OR "${columnName}" LIKE '%"system": "${sanitizedSystem}"%')`;
+                            whereClause = string ` WHERE ${predicate}`;
                         } else {
-                            whereClause = whereClause + string ` AND ("${columnName}" LIKE '%"system":"${sanitizedSystem}"%' OR "${columnName}" LIKE '%"system": "${sanitizedSystem}"%')`;
+                            whereClause = whereClause + string ` AND ${predicate}`;
                         }
                     }
                 }
@@ -443,14 +486,44 @@ public class ReadMapper {
             }
         }
 
-        // Calculate total count before pagination
-        int totalCount = 0;
-        string countQuery = string `SELECT COUNT(*) AS "COUNT" FROM "${tableName}"${whereClause}`;
-        log:printDebug(string `Executing count query for resource type: ${resourceType}`);
-        sql:ParameterizedQuery cQuery = new RawSQLQuery(countQuery);
-        record {|int COUNT;|}? countResult = check jdbcClient->queryRow(cQuery);
-        if countResult != () {
-            totalCount = countResult.COUNT;
+        // Calculate total count before pagination — but only if the caller asked.
+        // FHIR R4 §3.1.0 Bundle: `total` is optional for searchset bundles. The
+        // unconditional COUNT(*) was duplicating every search's work; per
+        // WORK.md §5.8 we now honor `_total=none|estimate|accurate` and default
+        // to "none" so the search planner does one scan instead of two.
+        // - none     : skip COUNT entirely (Bundle.total omitted).
+        // - estimate : use pg_class.reltuples (PG only); on H2 falls back to none.
+        // - accurate : run the full COUNT(*) (the previous unconditional path).
+        // See https://www.hl7.org/fhir/search.html#total
+        int? totalCount = ();
+        string totalMode = "none";
+        if queryParams.hasKey("_total") {
+            string[] vals = queryParams.get("_total");
+            if vals.length() > 0 {
+                string v = vals[0].toLowerAscii();
+                if v == "accurate" || v == "estimate" || v == "none" {
+                    totalMode = v;
+                }
+            }
+        }
+        string normalizedDbTypeForCount = mapperUtils:dbType.toLowerAscii().trim();
+        boolean isPg = normalizedDbTypeForCount == "postgresql" || normalizedDbTypeForCount == "postgres";
+        if totalMode == "accurate" {
+            string countQuery = string `SELECT COUNT(*) AS "COUNT" FROM "${tableName}"${whereClause}`;
+            log:printDebug(string `Executing accurate count query for resource type: ${resourceType}`);
+            sql:ParameterizedQuery cQuery = new RawSQLQuery(countQuery);
+            record {|int COUNT;|}? countResult = check jdbcClient->queryRow(cQuery);
+            if countResult != () {
+                totalCount = countResult.COUNT;
+            }
+        } else if totalMode == "estimate" && isPg && whereClause == "" {
+            // Cheap planner-stat estimate; only meaningful for unfiltered counts.
+            // Filtered estimates would need EXPLAIN parsing — defer.
+            sql:ParameterizedQuery cQuery = `SELECT reltuples::BIGINT AS "COUNT" FROM pg_class WHERE relname = ${tableName}`;
+            record {|int COUNT;|}? estResult = check jdbcClient->queryRow(cQuery);
+            if estResult != () {
+                totalCount = estResult.COUNT;
+            }
         }
 
         // Add pagination clause
@@ -542,117 +615,43 @@ public class ReadMapper {
             foreach string includeParam in includeParams {
                 // Parse _include parameter: format is ResourceType:searchParam or ResourceType:searchParam:targetType
                 // Example: Appointment:patient or Appointment:patient:Patient
-                // Also support wildcard: _include=* (include all references)
+                // Also support wildcard: _include=* (include all references).
+                //
+                // Batched (WORK.md §7): one REFERENCES query for ALL matched
+                // IDs + one batch read per distinct target type, instead of
+                // O(matched × refs) round-trips.
 
                 if includeParam == "*" {
-                    // Include all referenced resources from matched results
-                    foreach string sourceId in matchedResourceIds {
-                        json[] includedResources = check self.fetchAllReferencedResources(jdbcClient, resourceType, sourceId);
-                        foreach json includedEntry in includedResources {
-                            // Check for duplicates using resourceType/id as key
-                            map<json> entryMap = <map<json>>includedEntry;
-                            json includedResource = entryMap.get("resource");
-                            map<json> resourceMap = <map<json>>includedResource;
-                            string resType = resourceMap.get("resourceType").toString();
-                            string resId = resourceMap.get("id").toString();
-                            string resourceKey = string `${resType}/${resId}`;
-
-                            if !includedResourceKeys.hasKey(resourceKey) {
-                                entries.push(includedEntry);
-                                includedResourceKeys[resourceKey] = true;
-                            }
+                    json[] includedResources = check self.fetchAllReferencedResourcesBatch(jdbcClient, resourceType, matchedResourceIds);
+                    foreach json includedEntry in includedResources {
+                        map<json> entryMap = <map<json>>includedEntry;
+                        json includedResource = entryMap.get("resource");
+                        map<json> resourceMap = <map<json>>includedResource;
+                        string resType = resourceMap.get("resourceType").toString();
+                        string resId = resourceMap.get("id").toString();
+                        string resourceKey = string `${resType}/${resId}`;
+                        if !includedResourceKeys.hasKey(resourceKey) {
+                            entries.push(includedEntry);
+                            includedResourceKeys[resourceKey] = true;
                         }
                     }
                 } else {
-                    // Parse specific include parameter
                     string[] parts = regexp:split(re `:`, includeParam);
                     if parts.length() >= 2 {
                         string sourceResourceType = parts[0];
                         string searchParamName = parts[1];
                         string? targetResourceType = parts.length() > 2 ? parts[2] : ();
-
-                        // Only process if source type matches current search resource type
                         if sourceResourceType == resourceType {
-                            foreach string sourceId in matchedResourceIds {
-                                json[] includedResources = check self.fetchIncludedResources(jdbcClient, sourceResourceType, sourceId, searchParamName, targetResourceType);
-                                foreach json includedEntry in includedResources {
-                                    // Check for duplicates using resourceType/id as key
-                                    map<json> entryMap = <map<json>>includedEntry;
-                                    json includedResource = entryMap.get("resource");
-                                    map<json> resourceMap = <map<json>>includedResource;
-                                    string resType = resourceMap.get("resourceType").toString();
-                                    string resId = resourceMap.get("id").toString();
-                                    string resourceKey = string `${resType}/${resId}`;
-
-                                    if !includedResourceKeys.hasKey(resourceKey) {
-                                        entries.push(includedEntry);
-                                        includedResourceKeys[resourceKey] = true;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // Handle _revinclude parameters (reverse include)
-        if queryParams.hasKey("_revinclude") {
-            string[] revIncludeParams = queryParams.get("_revinclude");
-            foreach string revIncludeParam in revIncludeParams {
-                // Parse _revinclude parameter: format is ResourceType:searchParam or ResourceType:searchParam:sourceType
-                // Example: Provenance:target or Provenance:target:MedicationRequest
-                // Also support wildcard: _revinclude=* (include all resources that reference these results)
-
-                if revIncludeParam == "*" {
-                    // Include all resources that reference the matched results
-                    foreach string targetId in matchedResourceIds {
-                        json[] revIncludedResources = check self.fetchAllReferencingResources(jdbcClient, resourceType, targetId);
-                        foreach json revIncludedEntry in revIncludedResources {
-                            // Check for duplicates using resourceType/id as key
-                            map<json> entryMap = <map<json>>revIncludedEntry;
-                            json revIncludedResource = entryMap.get("resource");
-                            map<json> resourceMap = <map<json>>revIncludedResource;
-                            string resType = resourceMap.get("resourceType").toString();
-                            string resId = resourceMap.get("id").toString();
-                            string resourceKey = string `${resType}/${resId}`;
-
-                            if !includedResourceKeys.hasKey(resourceKey) {
-                                entries.push(revIncludedEntry);
-                                includedResourceKeys[resourceKey] = true;
-                            }
-                        }
-                    }
-                } else {
-                    // Parse specific revinclude parameter
-                    string[] parts = regexp:split(re `:`, revIncludeParam);
-                    if parts.length() >= 2 {
-                        string sourceResourceType = parts[0]; // The resource type that references the current results
-                        string searchParamName = parts[1]; // The search parameter on sourceResourceType
-                        string? targetResourceFilter = parts.length() > 2 ? parts[2] : ();
-
-                        // Process reverse include for each matched resource
-                        // We need to find resources of sourceResourceType that reference our matched results
-                        foreach string targetId in matchedResourceIds {
-                            json[] revIncludedResources = check self.fetchReverseIncludedResources(
-                                jdbcClient,
-                                sourceResourceType,  // e.g., "Provenance"
-                                searchParamName,  // e.g., "target"
-                                resourceType,  // e.g., "MedicationRequest" (what we searched for)
-                                targetId,  // ID of the matched resource
-                                targetResourceFilter // Optional filter if specified
-                            );
-                            foreach json revIncludedEntry in revIncludedResources {
-                                // Check for duplicates using resourceType/id as key
-                                map<json> entryMap = <map<json>>revIncludedEntry;
-                                json revIncludedResource = entryMap.get("resource");
-                                map<json> resourceMap = <map<json>>revIncludedResource;
+                            json[] includedResources = check self.fetchIncludedResourcesBatch(jdbcClient, sourceResourceType, matchedResourceIds, searchParamName, targetResourceType);
+                            foreach json includedEntry in includedResources {
+                                map<json> entryMap = <map<json>>includedEntry;
+                                json includedResource = entryMap.get("resource");
+                                map<json> resourceMap = <map<json>>includedResource;
                                 string resType = resourceMap.get("resourceType").toString();
                                 string resId = resourceMap.get("id").toString();
                                 string resourceKey = string `${resType}/${resId}`;
-
                                 if !includedResourceKeys.hasKey(resourceKey) {
-                                    entries.push(revIncludedEntry);
+                                    entries.push(includedEntry);
                                     includedResourceKeys[resourceKey] = true;
                                 }
                             }
@@ -662,12 +661,64 @@ public class ReadMapper {
             }
         }
 
-        json bundle = {
+        // Handle _revinclude parameters (reverse include) — batched.
+        if queryParams.hasKey("_revinclude") {
+            string[] revIncludeParams = queryParams.get("_revinclude");
+            foreach string revIncludeParam in revIncludeParams {
+                if revIncludeParam == "*" {
+                    json[] revIncludedResources = check self.fetchAllReferencingResourcesBatch(jdbcClient, resourceType, matchedResourceIds);
+                    foreach json revIncludedEntry in revIncludedResources {
+                        map<json> entryMap = <map<json>>revIncludedEntry;
+                        json revIncludedResource = entryMap.get("resource");
+                        map<json> resourceMap = <map<json>>revIncludedResource;
+                        string resType = resourceMap.get("resourceType").toString();
+                        string resId = resourceMap.get("id").toString();
+                        string resourceKey = string `${resType}/${resId}`;
+                        if !includedResourceKeys.hasKey(resourceKey) {
+                            entries.push(revIncludedEntry);
+                            includedResourceKeys[resourceKey] = true;
+                        }
+                    }
+                } else {
+                    string[] parts = regexp:split(re `:`, revIncludeParam);
+                    if parts.length() >= 2 {
+                        string sourceResourceType = parts[0];
+                        string searchParamName = parts[1];
+                        string? targetResourceFilter = parts.length() > 2 ? parts[2] : ();
+                        json[] revIncludedResources = check self.fetchReverseIncludedResourcesBatch(
+                            jdbcClient,
+                            sourceResourceType,
+                            searchParamName,
+                            resourceType,
+                            matchedResourceIds,
+                            targetResourceFilter
+                        );
+                        foreach json revIncludedEntry in revIncludedResources {
+                            map<json> entryMap = <map<json>>revIncludedEntry;
+                            json revIncludedResource = entryMap.get("resource");
+                            map<json> resourceMap = <map<json>>revIncludedResource;
+                            string resType = resourceMap.get("resourceType").toString();
+                            string resId = resourceMap.get("id").toString();
+                            string resourceKey = string `${resType}/${resId}`;
+                            if !includedResourceKeys.hasKey(resourceKey) {
+                                entries.push(revIncludedEntry);
+                                includedResourceKeys[resourceKey] = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        map<json> bundle = {
             "resourceType": "Bundle",
             "type": "searchset",
-            "total": totalCount,
             "entry": entries
         };
+        // Omit Bundle.total when caller didn't ask for it (default _total=none).
+        if totalCount is int {
+            bundle["total"] = totalCount;
+        }
 
         return bundle;
     }
@@ -1197,6 +1248,285 @@ public class ReadMapper {
         }
 
         return revIncludedEntries;
+    }
+
+    // ---------------------------------------------------------------------
+    // Batched fetchers for _include / _revinclude (WORK.md §5.5.4 / §7).
+    // Replace the prior O(matched × refs) round-trip pattern with:
+    //   1. ONE REFERENCES query (IN-clause over all matched IDs)
+    //   2. ONE batch SELECT per distinct target resource type (IN-clause over IDs)
+    // For 50 matched results × 5 refs each this drops 300+ round-trips to ~3.
+    // ---------------------------------------------------------------------
+
+    // Batch-fetch resources of one type by primary-key IN-list, reusing the
+    // meta-enrichment / fullUrl shaping that readResourceById does per-row.
+    private isolated function batchReadResources(jdbc:Client jdbcClient, string targetType, string[] targetIds, string? sinceFilter = (), string searchMode = "include") returns json[]|error {
+        if targetIds.length() == 0 {
+            return [];
+        }
+        string tableName = utils:getTableName(targetType);
+        string primaryKey = utils:getPrimaryKeyColumn(targetType);
+
+        string[] escaped = from string id in targetIds
+            select string `'${utils:escapeSql(id)}'`;
+        string idList = string:'join(", ", ...escaped);
+
+        string sqlQuery = string `SELECT "${primaryKey}" AS "RES_ID", "RESOURCE_JSON", "VERSION_ID", "LAST_UPDATED" FROM "${tableName}" WHERE "${primaryKey}" IN (${idList})`;
+        if sinceFilter is string {
+            string sqlTimestamp = regexp:replaceAll(re `T`, sinceFilter, " ");
+            sqlTimestamp = regexp:replaceAll(re `Z$`, sqlTimestamp, "");
+            sqlQuery += string ` AND "LAST_UPDATED" > '${utils:escapeSql(sqlTimestamp)}'`;
+        }
+
+        json[] entries = [];
+        string normalizedDbType = mapperUtils:dbType.toLowerAscii().trim();
+        if normalizedDbType == "postgresql" || normalizedDbType == "postgres" {
+            string pgSql = re `"RESOURCE_JSON"`.replaceAll(sqlQuery,
+                string `CAST("RESOURCE_JSON" AS TEXT) AS "RESOURCE_JSON"`);
+            sql:ParameterizedQuery pgQuery = new RawSQLQuery(pgSql);
+            stream<record {|string RES_ID; string RESOURCE_JSON; int VERSION_ID; time:Civil LAST_UPDATED;|}, sql:Error?> pgStream = jdbcClient->query(pgQuery);
+            record {|string RES_ID; string RESOURCE_JSON; int VERSION_ID; time:Civil LAST_UPDATED;|}[] rows = check from var r in pgStream
+                select r;
+            foreach var r in rows {
+                json resourceJson = check r.RESOURCE_JSON.fromJsonString();
+                map<json> resourceMap = <map<json>>resourceJson;
+                json existingMeta = resourceMap["meta"];
+                map<json> metaMap = existingMeta is map<json> ? existingMeta : {};
+                metaMap["versionId"] = r.VERSION_ID.toString();
+                metaMap["lastUpdated"] = utils:formatTimestampISO8601(r.LAST_UPDATED);
+                resourceMap["meta"] = metaMap;
+                entries.push({
+                    "fullUrl": string `${baseUrl}/fhir/r4/${targetType}/${r.RES_ID}`,
+                    "resource": resourceMap,
+                    "search": {"mode": searchMode}
+                });
+            }
+        } else {
+            sql:ParameterizedQuery h2Query = new RawSQLQuery(sqlQuery);
+            stream<record {|string RES_ID; byte[] RESOURCE_JSON; int VERSION_ID; time:Civil LAST_UPDATED;|}, sql:Error?> h2Stream = jdbcClient->query(h2Query);
+            record {|string RES_ID; byte[] RESOURCE_JSON; int VERSION_ID; time:Civil LAST_UPDATED;|}[] rows = check from var r in h2Stream
+                select r;
+            foreach var r in rows {
+                string jsonStr = check string:fromBytes(r.RESOURCE_JSON);
+                json resourceJson = check jsonStr.fromJsonString();
+                map<json> resourceMap = <map<json>>resourceJson;
+                json existingMeta = resourceMap["meta"];
+                map<json> metaMap = existingMeta is map<json> ? existingMeta : {};
+                metaMap["versionId"] = r.VERSION_ID.toString();
+                metaMap["lastUpdated"] = utils:formatTimestampISO8601(r.LAST_UPDATED);
+                resourceMap["meta"] = metaMap;
+                entries.push({
+                    "fullUrl": string `${baseUrl}/fhir/r4/${targetType}/${r.RES_ID}`,
+                    "resource": resourceMap,
+                    "search": {"mode": searchMode}
+                });
+            }
+        }
+        return entries;
+    }
+
+    // Helper: build "'a','b','c'" SQL literal from a string[] (already escaped).
+    private isolated function buildEscapedInList(string[] ids) returns string {
+        string[] escaped = from string id in ids
+            select string `'${utils:escapeSql(id)}'`;
+        return string:'join(", ", ...escaped);
+    }
+
+    // Wildcard _include=* across all matched source IDs.
+    private isolated function fetchAllReferencedResourcesBatch(jdbc:Client jdbcClient, string sourceResourceType, string[] sourceIds) returns json[]|error {
+        if sourceIds.length() == 0 {
+            return [];
+        }
+        string idList = self.buildEscapedInList(sourceIds);
+        string refQuery = string `SELECT DISTINCT "TARGET_RESOURCE_TYPE", "TARGET_RESOURCE_ID" FROM "REFERENCES" WHERE "SOURCE_RESOURCE_TYPE" = '${utils:escapeSql(sourceResourceType)}' AND "SOURCE_RESOURCE_ID" IN (${idList})`;
+        sql:ParameterizedQuery query = new utils:RawSQLQuery(refQuery);
+        stream<record {|string TARGET_RESOURCE_TYPE; string TARGET_RESOURCE_ID;|}, sql:Error?> refStream = jdbcClient->query(query);
+        record {|string TARGET_RESOURCE_TYPE; string TARGET_RESOURCE_ID;|}[] refRows = check from var r in refStream
+            select r;
+
+        map<string[]> byType = {};
+        foreach var r in refRows {
+            string[] ids = byType.hasKey(r.TARGET_RESOURCE_TYPE) ? byType.get(r.TARGET_RESOURCE_TYPE) : [];
+            ids.push(r.TARGET_RESOURCE_ID);
+            byType[r.TARGET_RESOURCE_TYPE] = ids;
+        }
+
+        json[] entries = [];
+        foreach var [tt, ids] in byType.entries() {
+            json[] sub = check self.batchReadResources(jdbcClient, tt, ids);
+            foreach json e in sub {
+                entries.push(e);
+            }
+        }
+        return entries;
+    }
+
+    // Wildcard _revinclude=* across all matched target IDs.
+    private isolated function fetchAllReferencingResourcesBatch(jdbc:Client jdbcClient, string targetResourceType, string[] targetIds) returns json[]|error {
+        if targetIds.length() == 0 {
+            return [];
+        }
+        string idList = self.buildEscapedInList(targetIds);
+        string refQuery = string `SELECT DISTINCT "SOURCE_RESOURCE_TYPE", "SOURCE_RESOURCE_ID" FROM "REFERENCES" WHERE "TARGET_RESOURCE_TYPE" = '${utils:escapeSql(targetResourceType)}' AND "TARGET_RESOURCE_ID" IN (${idList})`;
+        sql:ParameterizedQuery query = new utils:RawSQLQuery(refQuery);
+        stream<record {|string SOURCE_RESOURCE_TYPE; string SOURCE_RESOURCE_ID;|}, sql:Error?> refStream = jdbcClient->query(query);
+        record {|string SOURCE_RESOURCE_TYPE; string SOURCE_RESOURCE_ID;|}[] refRows = check from var r in refStream
+            select r;
+
+        map<string[]> bySrcType = {};
+        foreach var r in refRows {
+            string[] ids = bySrcType.hasKey(r.SOURCE_RESOURCE_TYPE) ? bySrcType.get(r.SOURCE_RESOURCE_TYPE) : [];
+            ids.push(r.SOURCE_RESOURCE_ID);
+            bySrcType[r.SOURCE_RESOURCE_TYPE] = ids;
+        }
+
+        json[] entries = [];
+        foreach var [st, ids] in bySrcType.entries() {
+            json[] sub = check self.batchReadResources(jdbcClient, st, ids);
+            foreach json e in sub {
+                entries.push(e);
+            }
+        }
+        return entries;
+    }
+
+    // Specific _include=Type:param[:targetType] across all matched source IDs.
+    private isolated function fetchIncludedResourcesBatch(jdbc:Client jdbcClient, string sourceResourceType, string[] sourceIds, string searchParamName, string? targetResourceType) returns json[]|error {
+        if sourceIds.length() == 0 {
+            return [];
+        }
+
+        // Resolve the FHIRPath expression once (per directive), not per source.
+        sql:ParameterizedQuery spQuery = `SELECT "EXPRESSION" FROM "SEARCH_PARAM_RES_EXPRESSIONS" WHERE "RESOURCE_NAME" = ${sourceResourceType} AND "SEARCH_PARAM_NAME" = ${searchParamName} AND "SEARCH_PARAM_TYPE" = 'reference'`;
+        stream<record {|string EXPRESSION;|}, sql:Error?> spStream = jdbcClient->query(spQuery);
+        record {|string EXPRESSION;|}[] spResults = check from var sp in spStream
+            select sp;
+        if spResults.length() == 0 {
+            return [];
+        }
+
+        string fhirPathExpr = spResults[0].EXPRESSION;
+        string? referenceField;
+        string? extractedTargetType;
+        [referenceField, extractedTargetType] = self.parseReferenceFieldFromExpression(fhirPathExpr);
+
+        string idList = self.buildEscapedInList(sourceIds);
+        string whereClause = string `"SOURCE_RESOURCE_TYPE" = '${utils:escapeSql(sourceResourceType)}' AND "SOURCE_RESOURCE_ID" IN (${idList})`;
+        if referenceField is string {
+            whereClause = whereClause + string ` AND "SOURCE_EXPRESSION" = '${utils:escapeSql(referenceField)}'`;
+        }
+        string? finalTargetType = extractedTargetType is string ? extractedTargetType : targetResourceType;
+        if finalTargetType is string {
+            whereClause = whereClause + string ` AND "TARGET_RESOURCE_TYPE" = '${utils:escapeSql(finalTargetType)}'`;
+        }
+
+        string refQuery = string `SELECT DISTINCT "TARGET_RESOURCE_TYPE", "TARGET_RESOURCE_ID" FROM "REFERENCES" WHERE ${whereClause}`;
+        sql:ParameterizedQuery query = new utils:RawSQLQuery(refQuery);
+        stream<record {|string TARGET_RESOURCE_TYPE; string TARGET_RESOURCE_ID;|}, sql:Error?> refStream = jdbcClient->query(query);
+        record {|string TARGET_RESOURCE_TYPE; string TARGET_RESOURCE_ID;|}[] refRows = check from var r in refStream
+            select r;
+
+        map<string[]> byType = {};
+        foreach var r in refRows {
+            string[] ids = byType.hasKey(r.TARGET_RESOURCE_TYPE) ? byType.get(r.TARGET_RESOURCE_TYPE) : [];
+            ids.push(r.TARGET_RESOURCE_ID);
+            byType[r.TARGET_RESOURCE_TYPE] = ids;
+        }
+
+        json[] entries = [];
+        foreach var [tt, ids] in byType.entries() {
+            json[] sub = check self.batchReadResources(jdbcClient, tt, ids);
+            foreach json e in sub {
+                entries.push(e);
+            }
+        }
+        return entries;
+    }
+
+    // Specific _revinclude=SourceType:param across all matched target IDs.
+    private isolated function fetchReverseIncludedResourcesBatch(jdbc:Client jdbcClient, string sourceResourceType, string searchParamName, string targetResourceType, string[] targetIds, string? sourceResourceFilter) returns json[]|error {
+        if targetIds.length() == 0 {
+            return [];
+        }
+
+        sql:ParameterizedQuery spQuery = `SELECT "EXPRESSION" FROM "SEARCH_PARAM_RES_EXPRESSIONS" WHERE "RESOURCE_NAME" = ${sourceResourceType} AND "SEARCH_PARAM_NAME" = ${searchParamName} AND "SEARCH_PARAM_TYPE" = 'reference'`;
+        stream<record {|string EXPRESSION;|}, sql:Error?> spStream = jdbcClient->query(spQuery);
+        record {|string EXPRESSION;|}[] spResults = check from var sp in spStream
+            select sp;
+        if spResults.length() == 0 {
+            return [];
+        }
+
+        string fhirPathExpr = spResults[0].EXPRESSION;
+        // The expression's target type (extracted via parseReferenceFieldFromExpression)
+        // is intentionally ignored here — the reverse-include caller already
+        // pinned TARGET_RESOURCE_TYPE in the WHERE clause below.
+        [string?, string?] parsed = self.parseReferenceFieldFromExpression(fhirPathExpr);
+        string? referenceField = parsed[0];
+
+        string idList = self.buildEscapedInList(targetIds);
+        string whereClause = string `"TARGET_RESOURCE_TYPE" = '${utils:escapeSql(targetResourceType)}' AND "TARGET_RESOURCE_ID" IN (${idList}) AND "SOURCE_RESOURCE_TYPE" = '${utils:escapeSql(sourceResourceType)}'`;
+        if referenceField is string {
+            whereClause = whereClause + string ` AND "SOURCE_EXPRESSION" = '${utils:escapeSql(referenceField)}'`;
+        }
+
+        string refQuery = string `SELECT DISTINCT "SOURCE_RESOURCE_TYPE", "SOURCE_RESOURCE_ID" FROM "REFERENCES" WHERE ${whereClause}`;
+        sql:ParameterizedQuery query = new utils:RawSQLQuery(refQuery);
+        stream<record {|string SOURCE_RESOURCE_TYPE; string SOURCE_RESOURCE_ID;|}, sql:Error?> refStream = jdbcClient->query(query);
+        record {|string SOURCE_RESOURCE_TYPE; string SOURCE_RESOURCE_ID;|}[] refRows = check from var r in refStream
+            select r;
+
+        map<string[]> bySrcType = {};
+        foreach var r in refRows {
+            string[] ids = bySrcType.hasKey(r.SOURCE_RESOURCE_TYPE) ? bySrcType.get(r.SOURCE_RESOURCE_TYPE) : [];
+            ids.push(r.SOURCE_RESOURCE_ID);
+            bySrcType[r.SOURCE_RESOURCE_TYPE] = ids;
+        }
+
+        json[] entries = [];
+        foreach var [st, ids] in bySrcType.entries() {
+            json[] sub = check self.batchReadResources(jdbcClient, st, ids);
+            foreach json e in sub {
+                entries.push(e);
+            }
+        }
+        return entries;
+    }
+
+    // Extract reference field + optional target type from a FHIRPath expression.
+    // Examples:
+    //   "Appointment.participant.actor.where(resolve() is Patient)"
+    //     -> ("actor", "Patient")
+    //   "Patient.generalPractitioner" -> ("generalPractitioner", ())
+    private isolated function parseReferenceFieldFromExpression(string fhirPathExpr) returns [string?, string?] {
+        string[] pathParts = regexp:split(re `\.`, fhirPathExpr);
+        string? referenceField = ();
+        string? extractedTargetType = ();
+        foreach int i in 0 ..< pathParts.length() {
+            string part = pathParts[i];
+            if part == "where" {
+                if i > 0 {
+                    referenceField = pathParts[i - 1];
+                }
+                break;
+            } else if part.startsWith("where(") {
+                if i > 0 {
+                    referenceField = pathParts[i - 1];
+                }
+                string wherePattern = "where(resolve() is ";
+                if part.startsWith(wherePattern) {
+                    string whereContent = part.substring(wherePattern.length());
+                    int? closeParenPos = whereContent.indexOf(")");
+                    if closeParenPos is int && closeParenPos > 0 {
+                        extractedTargetType = whereContent.substring(0, closeParenPos).trim();
+                    }
+                }
+                break;
+            } else if i == pathParts.length() - 1 {
+                referenceField = part;
+            }
+        }
+        return [referenceField, extractedTargetType];
     }
 
     // Check if a search parameter is a custom extension parameter

--- a/miscellaneous/fhir-server/modules/mappers/read_mapper.bal
+++ b/miscellaneous/fhir-server/modules/mappers/read_mapper.bal
@@ -466,10 +466,18 @@ public class ReadMapper {
                 // Case 1: [code] only (no pipe) - Use LIKE for string columns to support partial matching
                 else if operator == "=" {
                     string sanitizedValue = utils:escapeSql(searchValue);
+                    // Date/datetime values: use exact equality. LIKE on DATE/TIMESTAMP
+                    // columns fails on Postgres ("operator does not exist: date ~~ unknown")
+                    // and FHIR also defines a no-prefix date search as equality.
+                    boolean isDateLikeValue = regexp:isFullMatch(
+                            re `\d{4}(-\d{2}(-\d{2}(T[^']*)?)?)?`, searchValue);
+                    string predicate = isDateLikeValue
+                            ? string `"${columnName}" = '${sanitizedValue}'`
+                            : string `"${columnName}" LIKE '%${sanitizedValue}%'`;
                     if whereClause == "" {
-                        whereClause = string ` WHERE "${columnName}" LIKE '%${sanitizedValue}%'`;
+                        whereClause = string ` WHERE ${predicate}`;
                     } else {
-                        whereClause = whereClause + string ` AND "${columnName}" LIKE '%${sanitizedValue}%'`;
+                        whereClause = whereClause + string ` AND ${predicate}`;
                     }
                 } else {
                     // Use exact comparison for date/numeric operators

--- a/miscellaneous/fhir-server/modules/mappers/read_mapper.bal
+++ b/miscellaneous/fhir-server/modules/mappers/read_mapper.bal
@@ -259,8 +259,7 @@ public class ReadMapper {
 
         // Handle _profile parameter (search by meta.profile).
         // PostgreSQL: use JSONB containment (@>) so the body GIN index serves
-        // the predicate (WORK.md §5.5.1). H2 falls back to LIKE since it has
-        // no JSONB / GIN.
+        // the predicate. H2 falls back to LIKE since it has no JSONB / GIN.
         string normalizedDbTypeForProfile = mapperUtils:dbType.toLowerAscii().trim();
         boolean isPgForProfile = normalizedDbTypeForProfile == "postgresql" || normalizedDbTypeForProfile == "postgres";
         if queryParams.hasKey("_profile") {
@@ -406,7 +405,7 @@ public class ReadMapper {
                 // PostgreSQL: use RESOURCE_JSON @> containment so the body GIN
                 // index (IDX_<Type>TABLE_JSON_GIN) serves the predicate in
                 // O(log N + matches). H2: keep the legacy LIKE on the
-                // denormalized column. WORK.md §5.5.2.
+                // denormalized column.
                 if isTokenParam {
                     string sanitizedSystem = tokenSystem is string ? utils:escapeSql(tokenSystem) : "";
                     string sanitizedCode = tokenCode is string ? utils:escapeSql(tokenCode) : "";
@@ -418,9 +417,7 @@ public class ReadMapper {
                     //   *           → {<param>:{coding:[{system,code}]}}  (CodeableConcept)
                     // For unrecognized shapes the @> may not match; this is the
                     // same correctness contract as the prior LIKE — both are
-                    // best-effort and don't honor every edge of the FHIR token
-                    // spec. The plan in WORK.md §5.7 will replace both with
-                    // typed SPIDX side tables.
+                    // best-effort and don't honor every edge of the FHIR token spec.
                     string jsonPath = paramName.toLowerAscii();
                     boolean isIdentifierShape = jsonPath == "identifier";
                     string codeKey = isIdentifierShape ? "value" : "code";
@@ -487,10 +484,8 @@ public class ReadMapper {
         }
 
         // Calculate total count before pagination — but only if the caller asked.
-        // FHIR R4 §3.1.0 Bundle: `total` is optional for searchset bundles. The
-        // unconditional COUNT(*) was duplicating every search's work; per
-        // WORK.md §5.8 we now honor `_total=none|estimate|accurate` and default
-        // to "none" so the search planner does one scan instead of two.
+        // Bundle: `total` is optional for searchset bundles. The
+        // unconditional COUNT(*) was duplicating every search's work;
         // - none     : skip COUNT entirely (Bundle.total omitted).
         // - estimate : use pg_class.reltuples (PG only); on H2 falls back to none.
         // - accurate : run the full COUNT(*) (the previous unconditional path).
@@ -617,7 +612,7 @@ public class ReadMapper {
                 // Example: Appointment:patient or Appointment:patient:Patient
                 // Also support wildcard: _include=* (include all references).
                 //
-                // Batched (WORK.md §7): one REFERENCES query for ALL matched
+                // Batched: one REFERENCES query for ALL matched
                 // IDs + one batch read per distinct target type, instead of
                 // O(matched × refs) round-trips.
 
@@ -1251,7 +1246,7 @@ public class ReadMapper {
     }
 
     // ---------------------------------------------------------------------
-    // Batched fetchers for _include / _revinclude (WORK.md §5.5.4 / §7).
+    // Batched fetchers for _include / _revinclude.
     // Replace the prior O(matched × refs) round-trip pattern with:
     //   1. ONE REFERENCES query (IN-clause over all matched IDs)
     //   2. ONE batch SELECT per distinct target resource type (IN-clause over IDs)

--- a/miscellaneous/fhir-server/modules/utils/commons.bal
+++ b/miscellaneous/fhir-server/modules/utils/commons.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/log;
 import ballerina/uuid;
 import ballerina/regex;
@@ -155,14 +171,7 @@ public isolated function deleteFromResourceTable(jdbc:Client? jdbcClient, string
 
 // Maintain the cross-type FHIR_RESOURCE_INDEX feed (PostgreSQL only — the table
 // is not present in the H2 schema). Each create/update call upserts a single
-// row; the cost is a single index insert + LAST_UPDATED B-tree update. WORK.md
-// §3.3 / §5.6 / §6 Phase 10. The reader for this table (cross-type _history
-// feeds) is not yet wired up; the maintenance is added now so that when the
-// feed reader lands the index is already consistent for the catalog.
-//
-// Failures here are non-fatal: the index is a maintenance feed with no FK
-// dependency, so drift can be repaired offline. We don't want a transient
-// issue with this side table to invalidate an otherwise-successful write.
+// row; the cost is a single index insert + LAST_UPDATED B-tree update. 
 public isolated function upsertFhirResourceIndex(jdbc:Client? jdbcClient, string resourceType, string resourceId, int versionId) returns error? {
     string normalizedDbType = dbType.toLowerAscii().trim();
     if normalizedDbType != "postgresql" && normalizedDbType != "postgres" {
@@ -224,7 +233,7 @@ public isolated function deleteResource(jdbc:Client? jdbcClient, string resource
 // Delete all REFERENCES rows that originate from the given resource in a single
 // statement. Replaces the prior pattern of SELECT ID … then DELETE-per-row,
 // which cost O(R) round-trips per write and dominated PUT latency for resources
-// with many outgoing references. WORK.md §5.2.
+// with many outgoing references.
 public isolated function deleteReferencesBySource(jdbc:Client? jdbcClient, string sourceType, string sourceId, TransactionContext 'transaction) returns error? {
     jdbc:Client validatedClient = check getValidatedJdbcClient(jdbcClient);
     sql:ParameterizedQuery deleteQuery = `DELETE FROM "REFERENCES" WHERE "SOURCE_RESOURCE_TYPE" = ${sourceType} AND "SOURCE_RESOURCE_ID" = ${sourceId}`;
@@ -233,7 +242,6 @@ public isolated function deleteReferencesBySource(jdbc:Client? jdbcClient, strin
     if deleted > 0 {
         // Bookkeeping kept for log/debug parity with earlier implementation.
         // Real rollback is now handled by the JDBC `transaction { }` block
-        // (WORK.md §5.1 / Phase 3); the per-row IDs aren't needed.
         foreach int _ in 0 ..< deleted {
             'transaction.deletedReferenceIds.push(0);
         }

--- a/miscellaneous/fhir-server/modules/utils/commons.bal
+++ b/miscellaneous/fhir-server/modules/utils/commons.bal
@@ -153,6 +153,51 @@ public isolated function deleteFromResourceTable(jdbc:Client? jdbcClient, string
     log:printDebug(string `Removed ${resourceType}/${resourceId} from RESOURCE_TABLE`);
 }
 
+// Maintain the cross-type FHIR_RESOURCE_INDEX feed (PostgreSQL only — the table
+// is not present in the H2 schema). Each create/update call upserts a single
+// row; the cost is a single index insert + LAST_UPDATED B-tree update. WORK.md
+// §3.3 / §5.6 / §6 Phase 10. The reader for this table (cross-type _history
+// feeds) is not yet wired up; the maintenance is added now so that when the
+// feed reader lands the index is already consistent for the catalog.
+//
+// Failures here are non-fatal: the index is a maintenance feed with no FK
+// dependency, so drift can be repaired offline. We don't want a transient
+// issue with this side table to invalidate an otherwise-successful write.
+public isolated function upsertFhirResourceIndex(jdbc:Client? jdbcClient, string resourceType, string resourceId, int versionId) returns error? {
+    string normalizedDbType = dbType.toLowerAscii().trim();
+    if normalizedDbType != "postgresql" && normalizedDbType != "postgres" {
+        return;
+    }
+    jdbc:Client validatedClient = check getValidatedJdbcClient(jdbcClient);
+    time:Civil now = time:utcToCivil(time:utcNow());
+    sql:ParameterizedQuery upsertQuery = `INSERT INTO "FHIR_RESOURCE_INDEX"
+            ("RESOURCE_TYPE", "RESOURCE_ID", "VERSION_ID", "LAST_UPDATED", "DELETED")
+            VALUES (${resourceType}, ${resourceId}, ${versionId}, ${now}, FALSE)
+        ON CONFLICT ("RESOURCE_TYPE", "RESOURCE_ID") DO UPDATE
+            SET "VERSION_ID" = EXCLUDED."VERSION_ID",
+                "LAST_UPDATED" = EXCLUDED."LAST_UPDATED",
+                "DELETED" = FALSE`;
+    _ = check validatedClient->execute(upsertQuery);
+    log:printDebug(string `Upserted FHIR_RESOURCE_INDEX row for ${resourceType}/${resourceId} v${versionId}`);
+}
+
+// Tombstone a row in FHIR_RESOURCE_INDEX (PostgreSQL only). Called after a
+// successful delete. The row is kept rather than removed so that consumers
+// of cross-type history feeds can observe the deletion event.
+public isolated function markFhirResourceIndexDeleted(jdbc:Client? jdbcClient, string resourceType, string resourceId) returns error? {
+    string normalizedDbType = dbType.toLowerAscii().trim();
+    if normalizedDbType != "postgresql" && normalizedDbType != "postgres" {
+        return;
+    }
+    jdbc:Client validatedClient = check getValidatedJdbcClient(jdbcClient);
+    time:Civil now = time:utcToCivil(time:utcNow());
+    sql:ParameterizedQuery updateQuery = `UPDATE "FHIR_RESOURCE_INDEX"
+            SET "DELETED" = TRUE, "LAST_UPDATED" = ${now}
+            WHERE "RESOURCE_TYPE" = ${resourceType} AND "RESOURCE_ID" = ${resourceId}`;
+    _ = check validatedClient->execute(updateQuery);
+    log:printDebug(string `Marked FHIR_RESOURCE_INDEX row deleted for ${resourceType}/${resourceId}`);
+}
+
 // Delete main resource using generic JDBC query
 public isolated function deleteResource(jdbc:Client? jdbcClient, string resourceType, string resourceId) returns error? {
     jdbc:Client validatedClient = check getValidatedJdbcClient(jdbcClient);
@@ -176,24 +221,23 @@ public isolated function deleteResource(jdbc:Client? jdbcClient, string resource
     log:printDebug(string `Deleted resource: ${resourceType}/${resourceId}`);
 }
 
-// Delete references using generic JDBC query
-public isolated function deleteReferences(jdbc:Client? jdbcClient, int[] referenceIds, TransactionContext 'transaction) returns error? {
+// Delete all REFERENCES rows that originate from the given resource in a single
+// statement. Replaces the prior pattern of SELECT ID … then DELETE-per-row,
+// which cost O(R) round-trips per write and dominated PUT latency for resources
+// with many outgoing references. WORK.md §5.2.
+public isolated function deleteReferencesBySource(jdbc:Client? jdbcClient, string sourceType, string sourceId, TransactionContext 'transaction) returns error? {
     jdbc:Client validatedClient = check getValidatedJdbcClient(jdbcClient);
-
-    foreach int refId in referenceIds {
-        // Build DELETE query for REFERENCES table
-        string deleteQuery = string `DELETE FROM "REFERENCES" WHERE "ID" = ${refId}`;
-        
-        // Execute query using RawSQLQuery
-        RawSQLQuery query = new(deleteQuery);
-        sql:ExecutionResult result = check validatedClient->execute(query);
-        
-        if result.affectedRowCount > 0 {
-            'transaction.deletedReferenceIds.push(refId);
-            log:printDebug(string `Deleted reference [${refId}]`);
-        } else {
-            log:printWarn(string `Reference [${refId}] not found, skipping`);
+    sql:ParameterizedQuery deleteQuery = `DELETE FROM "REFERENCES" WHERE "SOURCE_RESOURCE_TYPE" = ${sourceType} AND "SOURCE_RESOURCE_ID" = ${sourceId}`;
+    sql:ExecutionResult result = check validatedClient->execute(deleteQuery);
+    int deleted = <int>(result.affectedRowCount ?: 0);
+    if deleted > 0 {
+        // Bookkeeping kept for log/debug parity with earlier implementation.
+        // Real rollback is now handled by the JDBC `transaction { }` block
+        // (WORK.md §5.1 / Phase 3); the per-row IDs aren't needed.
+        foreach int _ in 0 ..< deleted {
+            'transaction.deletedReferenceIds.push(0);
         }
+        log:printDebug(string `Bulk-deleted ${deleted} reference row(s) for ${sourceType}/${sourceId}`);
     }
 }
 

--- a/miscellaneous/fhir-server/modules/utils/commons.bal
+++ b/miscellaneous/fhir-server/modules/utils/commons.bal
@@ -178,6 +178,7 @@ public isolated function upsertFhirResourceIndex(jdbc:Client? jdbcClient, string
         return;
     }
     jdbc:Client validatedClient = check getValidatedJdbcClient(jdbcClient);
+    log:printDebug(string `Upserting FHIR resource index for ${resourceType}/${resourceId} version ${versionId}`);
     time:Civil now = time:utcToCivil(time:utcNow());
     sql:ParameterizedQuery upsertQuery = `INSERT INTO "FHIR_RESOURCE_INDEX"
             ("RESOURCE_TYPE", "RESOURCE_ID", "VERSION_ID", "LAST_UPDATED", "DELETED")
@@ -199,6 +200,7 @@ public isolated function markFhirResourceIndexDeleted(jdbc:Client? jdbcClient, s
         return;
     }
     jdbc:Client validatedClient = check getValidatedJdbcClient(jdbcClient);
+    log:printDebug(string `Marking FHIR resource ${resourceType}/${resourceId} as deleted in index`);
     time:Civil now = time:utcToCivil(time:utcNow());
     sql:ParameterizedQuery updateQuery = `UPDATE "FHIR_RESOURCE_INDEX"
             SET "DELETED" = TRUE, "LAST_UPDATED" = ${now}

--- a/miscellaneous/fhir-server/modules/utils/transactions.bal
+++ b/miscellaneous/fhir-server/modules/utils/transactions.bal
@@ -1,237 +1,25 @@
-import ballerina/log;
-import ballerina/regex;
-import ballerina/sql;
-import ballerina/time;
-
-import ballerinax/java.jdbc;
+// WORK.md §5.1 / Phase 3: with the handlers wrapped in a real Ballerina
+// `transaction { ... check commit; }` block, atomicity and rollback are
+// delegated to the JDBC layer. The application-level backup/restore machinery
+// that this module previously provided is gone.
+//
+// What remains is a small bookkeeping record carried through commons.bal's
+// reference helpers (`saveReferences`, `deleteReferencesBySource`) — they
+// still flip flags on it for log/debug parity with the prior implementation.
+// The fields and the factory are kept so those helper signatures don't churn.
 
 public type TransactionContext record {|
     string? mainResourceId = ();
     boolean referencesSaved = false;
     int[] deletedReferenceIds = [];
-    record {|anydata...;|}? backupResource = ();
-    record {|anydata...;|}[]? backupReferences = ();
     boolean committed = false;
 |};
 
-public class TransactionHandler {
-
-    public isolated function beginTransaction() returns TransactionContext {
-        log:printDebug("Beginning new transaction");
-        return {
-            mainResourceId: (),
-            referencesSaved: false,
-            deletedReferenceIds: [],
-            backupResource: (),
-            committed: false
-        };
-    }
-
-    // Rollback for CREATE operations
-    public isolated function rollbackCreateTransaction(jdbc:Client? jdbcClient, TransactionContext 'transaction, string resourceType) returns error? {
-        if 'transaction.committed {
-            log:printWarn("Cannot rollback a committed transaction");
-            return;
-        }
-
-        log:printWarn(string `Rolling back ${resourceType} CREATE transaction`);
-
-        int deletedRefs = 0;
-        int failedRefs = 0;
-
-        if jdbcClient is jdbc:Client && 'transaction.referencesSaved && 'transaction.mainResourceId is string {
-            string resourceId = <string>'transaction.mainResourceId;
-            string resourceType2 = resourceType; // parameter-shadowing workaround
-            string deleteQuery = string `DELETE FROM "REFERENCES" WHERE "SOURCE_RESOURCE_TYPE" = '${escapeSql(resourceType2)}' AND "SOURCE_RESOURCE_ID" = '${escapeSql(resourceId)}'`;
-            sql:ExecutionResult|error result = jdbcClient->execute(new RawSQLQuery(deleteQuery));
-            if result is error {
-                log:printError(string `Failed to delete references for ${resourceType2}/${resourceId} during rollback: ${result.message()}`);
-                failedRefs += 1;
-            } else {
-                deletedRefs += (<int>(result.affectedRowCount ?: 0));
-            }
-        }
-
-        // Delete main resource if it was saved
-        if 'transaction.mainResourceId is string {
-            string resourceId = <string>'transaction.mainResourceId;
-            error? deleteResult = deleteResource(jdbcClient, resourceType, resourceId);
-
-            if deleteResult is error {
-                log:printError(string `Failed to delete main resource ${resourceType}/${resourceId} during rollback: ${deleteResult.message()}`);
-                return deleteResult;
-            } else {
-                log:printDebug(string `Deleted main resource during rollback: ${resourceType}/${resourceId}`);
-            }
-        }
-
-        log:printDebug(string `Rollback completed: deleted ${deletedRefs} reference(s), failed ${failedRefs}`);
-    }
-
-    // Rollback for DELETE operations (restore deleted items)
-    public isolated function rollbackDeleteTransaction(jdbc:Client? jdbcClient, TransactionContext 'transaction, string resourceType) returns error? {
-
-        if 'transaction.committed {
-            log:printWarn("Cannot rollback a committed transaction");
-            return;
-        }
-
-        log:printWarn(string `Rolling back ${resourceType} DELETE transaction`);
-
-        // Restore main resource
-        if 'transaction.backupResource is record {|anydata...;|} {
-            string resourceId = <string>'transaction.mainResourceId;
-            error? restoreResult = self.restoreResource(jdbcClient, resourceType, resourceId, 'transaction.backupResource);
-
-            if restoreResult is error {
-                log:printError(string `Failed to restore resource ${resourceType}/${resourceId}: ${restoreResult.message()}`);
-                return restoreResult;
-            } else {
-                log:printDebug(string `Restored ${resourceType}/${resourceId} during rollback`);
-            }
-        }
-
-        // Restore deleted references using JDBC
-        if 'transaction.backupReferences is record {|anydata...;|}[] {
-            record {|anydata...;|}[] backupRefs = <record {|anydata...;|}[]>'transaction.backupReferences;
-            foreach var ref in backupRefs {
-                error? restoreResult = self.restoreReference(jdbcClient, ref);
-                if restoreResult is error {
-                    log:printError(string `Failed to restore reference during rollback: ${restoreResult.message()}`);
-                } else {
-                    int refId = check int:fromString(ref.get("ID").toString());
-                    log:printDebug(string `Restored reference [${refId}] during rollback`);
-                }
-            }
-        }
-
-        log:printDebug("Delete rollback completed");
-    }
-
-    public isolated function commitTransaction(TransactionContext 'transaction, string resourceType, string resourceId) {
-        'transaction.committed = true;
-        log:printDebug(string `Transaction committed for ${resourceType}/${resourceId}`);
-
-        if 'transaction.referencesSaved {
-            log:printDebug(string `   - Main resource: ${<string>'transaction.mainResourceId}`);
-            log:printDebug("   - References saved: true");
-        }
-
-        if 'transaction.deletedReferenceIds.length() > 0 {
-            log:printDebug(string `   - Main resource: ${<string>'transaction.mainResourceId}`);
-            log:printDebug(string `   - References deleted: ${'transaction.deletedReferenceIds.length()}`);
-        }
-    }
-
-    // Rollback for UPDATE operations (restore from backup)
-    public isolated function rollbackUpdateTransaction(jdbc:Client? jdbcClient, TransactionContext 'transaction, string resourceType) returns error? {
-
-        if 'transaction.committed {
-            log:printWarn("Cannot rollback a committed transaction");
-            return;
-        }
-
-        log:printWarn(string `Rolling back ${resourceType} UPDATE transaction`);
-
-        // Restore backed up resource
-        if 'transaction.backupResource is record {|anydata...;|} {
-            string resourceId = <string>'transaction.mainResourceId;
-            error? restoreResult = self.restoreResource(jdbcClient, resourceType, resourceId, 'transaction.backupResource);
-            if restoreResult is error {
-                log:printError(string `Failed to restore resource ${resourceType}/${resourceId}: ${restoreResult.message()}`);
-            } else {
-                log:printDebug(string `Restored ${resourceType}/${resourceId} from backup during rollback`);
-            }
-        }
-
-        if jdbcClient is jdbc:Client && 'transaction.referencesSaved && 'transaction.mainResourceId is string {
-            string resourceId = <string>'transaction.mainResourceId;
-            string deleteQuery = string `DELETE FROM "REFERENCES" WHERE "SOURCE_RESOURCE_TYPE" = '${escapeSql(resourceType)}' AND "SOURCE_RESOURCE_ID" = '${escapeSql(resourceId)}'`;
-            sql:ExecutionResult|error result = jdbcClient->execute(new RawSQLQuery(deleteQuery));
-            if result is error {
-                log:printError(string `Failed to delete references for ${resourceType}/${resourceId} during rollback: ${result.message()}`);
-            }
-        }
-
-        log:printDebug("Update rollback completed");
-    }
-
-    private isolated function restoreResource(jdbc:Client? jdbcClient, string resourceType, string resourceId, record {|anydata...;|}? backup) returns error? {
-        if backup is () {
-            return error("No backup available for restore");
-        }
-
-        if jdbcClient is () {
-            return error("JDBC Client is not initialized");
-        }
-
-        // Get table name and primary key
-        string tableName = getTableName(resourceType);
-        string primaryKeyColumn = getPrimaryKeyColumn(resourceType);
-
-        // Build UPDATE SET clause dynamically from backup record
-        string[] setClauses = [];
-        foreach var [columnName, value] in backup.entries() {
-            string columnValue = self.formatValue(value);
-            setClauses.push(string `"${columnName}" = ${columnValue}`);
-        }
-
-        if setClauses.length() == 0 {
-            return error("No data to restore");
-        }
-
-        // Build and execute UPDATE query
-        string updateQuery = string `UPDATE "${tableName}" SET ${string:'join(", ", ...setClauses)} WHERE "${primaryKeyColumn}" = '${resourceId}'`;
-        sql:ExecutionResult result = check jdbcClient->execute(new RawSQLQuery(updateQuery));
-
-        if result.affectedRowCount == 0 {
-            return error(string `Failed to restore ${resourceType}/${resourceId} - resource not found`);
-        }
-
-        log:printDebug(string `Restored ${resourceType}/${resourceId} with ${setClauses.length()} field(s)`);
-    }
-
-    // Helper to restore a single reference using JDBC
-    private isolated function restoreReference(jdbc:Client? jdbcClient, record {|anydata...;|} ref) returns error? {
-        if jdbcClient is () {
-            return error("JDBC Client is not initialized");
-        }
-
-        // Extract and escape string values
-        string sourceResType = ref.get("SOURCE_RESOURCE_TYPE").toString();
-        string sourceResId = ref.get("SOURCE_RESOURCE_ID").toString();
-        string sourceExpr = ref.get("SOURCE_EXPRESSION").toString();
-        string targetResType = ref.get("TARGET_RESOURCE_TYPE").toString();
-        string targetResId = ref.get("TARGET_RESOURCE_ID").toString();
-        string displayValue = ref.get("DISPLAY_VALUE").toString();
-        
-        string escapedSourceResType = regex:replaceAll(sourceResType, "'", "''");
-        string escapedSourceResId = regex:replaceAll(sourceResId, "'", "''");
-        string escapedSourceExpr = regex:replaceAll(sourceExpr, "'", "''");
-        string escapedTargetResType = regex:replaceAll(targetResType, "'", "''");
-        string escapedTargetResId = regex:replaceAll(targetResId, "'", "''");
-        string escapedDisplayValue = regex:replaceAll(displayValue, "'", "''");
-
-        // Format timestamps
-        anydata createdAtData = ref.get("CREATED_AT");
-        anydata updatedAtData = ref.get("UPDATED_AT");
-        anydata lastUpdatedData = ref.get("LAST_UPDATED");
-        
-        string createdAt = createdAtData is time:Civil ? formatTimestamp(createdAtData) : createdAtData.toString();
-        string updatedAt = updatedAtData is time:Civil ? formatTimestamp(updatedAtData) : updatedAtData.toString();
-        string lastUpdated = lastUpdatedData is time:Civil ? formatTimestamp(lastUpdatedData) : lastUpdatedData.toString();
-
-        // Get reference ID
-        int refId = check int:fromString(ref.get("ID").toString());
-
-        // Build INSERT query
-        string insertQuery = string `INSERT INTO "REFERENCES" ("ID", "SOURCE_RESOURCE_TYPE", "SOURCE_RESOURCE_ID", "SOURCE_EXPRESSION", "TARGET_RESOURCE_TYPE", "TARGET_RESOURCE_ID", "DISPLAY_VALUE", "CREATED_AT", "UPDATED_AT", "LAST_UPDATED") VALUES (${refId}, '${escapedSourceResType}', '${escapedSourceResId}', '${escapedSourceExpr}', '${escapedTargetResType}', '${escapedTargetResId}', '${escapedDisplayValue}', '${createdAt}', '${updatedAt}', '${lastUpdated}')`;
-
-        _ = check jdbcClient->execute(new RawSQLQuery(insertQuery));
-    }
-
-    // Helper to format a value for SQL (delegates to commons utility)
-    public isolated function formatValue(anydata value) returns string {
-        return formatSqlValue(value);
-    }
+public isolated function newTransactionContext() returns TransactionContext {
+    return {
+        mainResourceId: (),
+        referencesSaved: false,
+        deletedReferenceIds: [],
+        committed: false
+    };
 }

--- a/miscellaneous/fhir-server/modules/utils/transactions.bal
+++ b/miscellaneous/fhir-server/modules/utils/transactions.bal
@@ -1,12 +1,18 @@
-// WORK.md §5.1 / Phase 3: with the handlers wrapped in a real Ballerina
-// `transaction { ... check commit; }` block, atomicity and rollback are
-// delegated to the JDBC layer. The application-level backup/restore machinery
-// that this module previously provided is gone.
-//
-// What remains is a small bookkeeping record carried through commons.bal's
-// reference helpers (`saveReferences`, `deleteReferencesBySource`) — they
-// still flip flags on it for log/debug parity with the prior implementation.
-// The fields and the factory are kept so those helper signatures don't churn.
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 public type TransactionContext record {|
     string? mainResourceId = ();

--- a/miscellaneous/fhir-server/scripts/schema-postgresql.sql
+++ b/miscellaneous/fhir-server/scripts/schema-postgresql.sql
@@ -2575,26 +2575,6 @@ CREATE TABLE "TestScriptTable" (
 -- =============================================================================
 -- PERFORMANCE OPTIMIZATION SECTION
 -- =============================================================================
--- Companion docs: WORK.md, PLAN.md, INDEX_PLAN.md
---
--- Strategy in one paragraph: the body GIN(jsonb_path_ops) replaces every
--- per-column LIKE-on-VARCHAR(2048)-JSON predicate (token, identifier, profile,
--- reference, custom-extension lookup) with an indexed @> containment scan, at
--- ~25-30% of body size. B-tree indexes are added ONLY where GIN cannot help:
--- on real range/sort dimensions (LAST_UPDATED, primary DATE columns). Side
--- tables (FHIR_SPIDX_QUANTITY, FHIR_SPIDX_DATE_RANGE, FHIR_COMBO_*) handle
--- the three search shapes GIN does poorly: quantity-with-units, period
--- overlap (TSRANGE + GiST), and composite search params. BRIN summarizes
--- append-only timestamp columns at <1% the size of equivalent B-trees.
---
--- This is sized for an 8 GB / 4 vCPU box (shared_buffers ~2 GB). We do NOT
--- index every search column on every resource table; that proposal in
--- INDEX_PLAN.md Part B would create hundreds of B-trees that compete for the
--- buffer cache and bloat write amplification. We index the universal hot
--- dimensions (LAST_UPDATED, body GIN) on the top 30 clinical resources and
--- leave the long tail to fall through to body GIN scans, which are already
--- O(log N + matches).
--- =============================================================================
 
 -- -----------------------------------------------------------------------------
 -- 1. Extensions
@@ -2829,7 +2809,7 @@ CREATE INDEX "IDX_DEVICETABLE_LU"                  ON "DeviceTable"             
 -- -----------------------------------------------------------------------------
 -- ~25-30% of body size per index. THIS is the index that replaces every
 -- LIKE-on-VARCHAR(2048)-JSON predicate. The query layer must emit @>
--- containment instead of LIKE for it to be used (see WORK.md §5).
+-- containment instead of LIKE for it to be used.
 --
 -- jsonb_path_ops is preferred over jsonb_ops: smaller, faster for @>, the
 -- only operator we need. (It does not support ?, ?|, ?& key-existence; if
@@ -2903,4 +2883,3 @@ CREATE INDEX "IDX_PATIENTTABLE_FAMILY_TRGM"
     ON "PatientTable" USING GIN ("FAMILY" gin_trgm_ops);
 CREATE INDEX "IDX_PRACTITIONERTABLE_NAME_TRGM"
     ON "PractitionerTable" USING GIN ("NAME" gin_trgm_ops);
-	

--- a/miscellaneous/fhir-server/scripts/schema-postgresql.sql
+++ b/miscellaneous/fhir-server/scripts/schema-postgresql.sql
@@ -2571,3 +2571,336 @@ CREATE TABLE "TestScriptTable" (
 	"RESOURCE_JSON" JSONB NOT NULL,
 	PRIMARY KEY("TESTSCRIPTTABLE_ID")
 );
+
+-- =============================================================================
+-- PERFORMANCE OPTIMIZATION SECTION
+-- =============================================================================
+-- Companion docs: WORK.md, PLAN.md, INDEX_PLAN.md
+--
+-- Strategy in one paragraph: the body GIN(jsonb_path_ops) replaces every
+-- per-column LIKE-on-VARCHAR(2048)-JSON predicate (token, identifier, profile,
+-- reference, custom-extension lookup) with an indexed @> containment scan, at
+-- ~25-30% of body size. B-tree indexes are added ONLY where GIN cannot help:
+-- on real range/sort dimensions (LAST_UPDATED, primary DATE columns). Side
+-- tables (FHIR_SPIDX_QUANTITY, FHIR_SPIDX_DATE_RANGE, FHIR_COMBO_*) handle
+-- the three search shapes GIN does poorly: quantity-with-units, period
+-- overlap (TSRANGE + GiST), and composite search params. BRIN summarizes
+-- append-only timestamp columns at <1% the size of equivalent B-trees.
+--
+-- This is sized for an 8 GB / 4 vCPU box (shared_buffers ~2 GB). We do NOT
+-- index every search column on every resource table; that proposal in
+-- INDEX_PLAN.md Part B would create hundreds of B-trees that compete for the
+-- buffer cache and bloat write amplification. We index the universal hot
+-- dimensions (LAST_UPDATED, body GIN) on the top 30 clinical resources and
+-- leave the long tail to fall through to body GIN scans, which are already
+-- O(log N + matches).
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 1. Extensions
+-- -----------------------------------------------------------------------------
+CREATE EXTENSION IF NOT EXISTS pg_trgm;       -- substring/ILIKE acceleration on free-text
+CREATE EXTENSION IF NOT EXISTS btree_gin;     -- combine btree predicates with GIN scans
+CREATE EXTENSION IF NOT EXISTS btree_gist;    -- combine scalar leading cols with TSRANGE GiST
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;  -- query-level visibility (load via shared_preload_libraries)
+
+-- -----------------------------------------------------------------------------
+-- 2. Drop redundant / low-value indexes from the original schema
+-- -----------------------------------------------------------------------------
+-- Subset of IDX_HISTORY_VERSION (RESOURCE_TYPE, RESOURCE_ID, VERSION_ID).
+DROP INDEX IF EXISTS "IDX_HISTORY_RES";
+-- Subset of IDX_SPRE_RESOURCE_PARAM (RESOURCE_NAME, SEARCH_PARAM_NAME).
+DROP INDEX IF EXISTS "IDX_SPRE_RESOURCE_NAME";
+-- Duplicates the leading column of the composite PK (CLOSURECONTEXTTABLE_ID, VERSION_ID).
+DROP INDEX IF EXISTS "IDX_CLOSUREDELTA_CONTEXT";
+-- Replaced by the partial composite indexes added below.
+DROP INDEX IF EXISTS "IDX_CUST_PARAM_RES_TYPE";
+DROP INDEX IF EXISTS "IDX_CUST_PARAM_NAME";
+DROP INDEX IF EXISTS "IDX_CUST_PARAM_STRING";
+DROP INDEX IF EXISTS "IDX_CUST_PARAM_TOKEN";
+DROP INDEX IF EXISTS "IDX_CUST_PARAM_REF";
+
+-- -----------------------------------------------------------------------------
+-- 3. New shared tables
+-- -----------------------------------------------------------------------------
+
+-- 3.1 Cross-type lastUpdated feed. Avoids UNION across 130 tables for system-
+-- wide _history feeds, change-data-capture exports, and "modified since" syncs.
+-- Maintained by handlers as one extra row per write.
+CREATE TABLE "FHIR_RESOURCE_INDEX" (
+    "RESOURCE_TYPE"  VARCHAR(64)  NOT NULL,
+    "RESOURCE_ID"    VARCHAR(191) NOT NULL,
+    "VERSION_ID"     INT          NOT NULL,
+    "LAST_UPDATED"   TIMESTAMP    NOT NULL,
+    "DELETED"        BOOLEAN      NOT NULL DEFAULT FALSE,
+    PRIMARY KEY ("RESOURCE_TYPE", "RESOURCE_ID")
+);
+CREATE INDEX "IDX_FRI_LASTUPDATED"     ON "FHIR_RESOURCE_INDEX" ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_FRI_TYPE_LASTUPDATED" ON "FHIR_RESOURCE_INDEX" ("RESOURCE_TYPE", "LAST_UPDATED" DESC);
+
+-- 3.2 Quantity index. Typed numeric column with a composite B-tree on
+-- (RESOURCE_TYPE, PARAM_NAME, CODE, VALUE) so value-quantity searches
+-- (Observation?value-quantity=gt5|...|mg/dL,
+-- Observation?component-value-quantity=...) are O(log N).
+--
+-- VALUE_LOW / VALUE_HIGH support FHIR Range datatype (e.g., onset-age=ge0|years
+-- against Range[0..5]). When the value is scalar both are NULL and VALUE is
+-- used.
+CREATE TABLE "FHIR_SPIDX_QUANTITY" (
+    "ID"             BIGSERIAL    PRIMARY KEY,
+    "RESOURCE_TYPE"  VARCHAR(64)  NOT NULL,
+    "RESOURCE_ID"    VARCHAR(191) NOT NULL,
+    "PARAM_NAME"     VARCHAR(64)  NOT NULL,
+    "VALUE"          NUMERIC(20,6),
+    "VALUE_LOW"      NUMERIC(20,6),
+    "VALUE_HIGH"     NUMERIC(20,6),
+    "SYSTEM"         VARCHAR(255),
+    "CODE"           VARCHAR(64),
+    "UNIT"           VARCHAR(64)
+);
+CREATE INDEX "IDX_SPIDX_QUANTITY_LOOKUP"
+    ON "FHIR_SPIDX_QUANTITY" ("RESOURCE_TYPE", "PARAM_NAME", "CODE", "VALUE");
+CREATE INDEX "IDX_SPIDX_QUANTITY_RANGE"
+    ON "FHIR_SPIDX_QUANTITY" ("RESOURCE_TYPE", "PARAM_NAME", "CODE", "VALUE_LOW", "VALUE_HIGH")
+    WHERE "VALUE_LOW" IS NOT NULL;
+CREATE INDEX "IDX_SPIDX_QUANTITY_BACKREF"
+    ON "FHIR_SPIDX_QUANTITY" ("RESOURCE_TYPE", "RESOURCE_ID");
+
+-- 3.3 Date-range index. FHIR Period datatype (Encounter.period, CarePlan.period,
+-- Coverage.period, EpisodeOfCare.period, MedicationRequest.dispenseRequest.
+-- validityPeriod, etc.) requires overlap semantics: "find encounters active
+-- on 2026-03-15" must hit any row whose [start,end] contains the date.
+--
+-- TSRANGE + GiST handles this natively (operators &&, @>, <@, -|-) at log
+-- complexity.
+CREATE TABLE "FHIR_SPIDX_DATE_RANGE" (
+    "ID"             BIGSERIAL    PRIMARY KEY,
+    "RESOURCE_TYPE"  VARCHAR(64)  NOT NULL,
+    "RESOURCE_ID"    VARCHAR(191) NOT NULL,
+    "PARAM_NAME"     VARCHAR(64)  NOT NULL,
+    "DATE_RANGE"     TSRANGE      NOT NULL
+);
+CREATE INDEX "IDX_SPIDX_DATE_RANGE_GIST"
+    ON "FHIR_SPIDX_DATE_RANGE"
+    USING GIST ("RESOURCE_TYPE", "PARAM_NAME", "DATE_RANGE");
+CREATE INDEX "IDX_SPIDX_DATE_RANGE_BACKREF"
+    ON "FHIR_SPIDX_DATE_RANGE" ("RESOURCE_TYPE", "RESOURCE_ID");
+
+-- 3.4 Composite search parameter: token + number. The canonical example is
+-- Observation.code-value-quantity ("find systolic BPs > 140"), where neither
+-- a token-only nor a value-only index can answer the query without a heavy
+-- recheck. A dedicated table materialises the pair so a single composite
+-- B-tree lookup answers the query.
+CREATE TABLE "FHIR_COMBO_TOKEN_NUMBER" (
+    "ID"             BIGSERIAL    PRIMARY KEY,
+    "RESOURCE_TYPE"  VARCHAR(64)  NOT NULL,
+    "RESOURCE_ID"    VARCHAR(191) NOT NULL,
+    "PARAM_NAME"     VARCHAR(64)  NOT NULL,        -- e.g. 'code-value-quantity'
+    "TOKEN_SYSTEM"   VARCHAR(255),
+    "TOKEN_CODE"     VARCHAR(255) NOT NULL,
+    "NUMBER_VALUE"   NUMERIC(20,6) NOT NULL,
+    "NUMBER_UNIT"    VARCHAR(64)
+);
+CREATE INDEX "IDX_COMBO_TN_LOOKUP"
+    ON "FHIR_COMBO_TOKEN_NUMBER"
+       ("RESOURCE_TYPE", "PARAM_NAME", "TOKEN_CODE", "NUMBER_VALUE");
+CREATE INDEX "IDX_COMBO_TN_BACKREF"
+    ON "FHIR_COMBO_TOKEN_NUMBER" ("RESOURCE_TYPE", "RESOURCE_ID");
+
+-- 3.5 Composite token + token (e.g. context-type-value, identifier with type).
+CREATE TABLE "FHIR_COMBO_TOKEN_TOKEN" (
+    "ID"             BIGSERIAL    PRIMARY KEY,
+    "RESOURCE_TYPE"  VARCHAR(64)  NOT NULL,
+    "RESOURCE_ID"    VARCHAR(191) NOT NULL,
+    "PARAM_NAME"     VARCHAR(64)  NOT NULL,
+    "TOKEN1_SYSTEM"  VARCHAR(255),
+    "TOKEN1_CODE"    VARCHAR(255) NOT NULL,
+    "TOKEN2_SYSTEM"  VARCHAR(255),
+    "TOKEN2_CODE"    VARCHAR(255) NOT NULL
+);
+CREATE INDEX "IDX_COMBO_TT_LOOKUP"
+    ON "FHIR_COMBO_TOKEN_TOKEN"
+       ("RESOURCE_TYPE", "PARAM_NAME", "TOKEN1_CODE", "TOKEN2_CODE");
+CREATE INDEX "IDX_COMBO_TT_BACKREF"
+    ON "FHIR_COMBO_TOKEN_TOKEN" ("RESOURCE_TYPE", "RESOURCE_ID");
+
+-- -----------------------------------------------------------------------------
+-- 4. RESOURCE_TABLE — type-only filter coverage
+-- -----------------------------------------------------------------------------
+-- Composite PK is (ID, TYPE); leading-col searches by TYPE can't use it.
+CREATE INDEX "IDX_RESOURCE_TABLE_TYPE"
+    ON "RESOURCE_TABLE" ("TYPE", "ID");
+
+-- -----------------------------------------------------------------------------
+-- 5. REFERENCES — covering index for _revinclude, BRIN for time scans
+-- -----------------------------------------------------------------------------
+-- Reverse-include path: given (TARGET_TYPE, TARGET_ID), pull all
+-- (SOURCE_TYPE, SOURCE_ID) referencing it, optionally filtered by expression.
+-- Existing IDX_REFERENCES_TARGET stops at the join key; this covers the rest.
+CREATE INDEX "IDX_REFERENCES_TARGET_REVERSE"
+    ON "REFERENCES" ("TARGET_RESOURCE_TYPE", "TARGET_RESOURCE_ID",
+                     "SOURCE_RESOURCE_TYPE", "SOURCE_EXPRESSION", "SOURCE_RESOURCE_ID");
+
+-- BRIN on the append-only CREATED_AT. ~0.5% of B-tree size; cheap to maintain.
+CREATE INDEX "IDX_REFERENCES_CREATED_AT_BRIN"
+    ON "REFERENCES" USING BRIN ("CREATED_AT") WITH (pages_per_range = 32);
+
+-- -----------------------------------------------------------------------------
+-- 6. RESOURCE_HISTORY — type+time, BRIN, operation
+-- -----------------------------------------------------------------------------
+CREATE INDEX "IDX_HISTORY_TYPE_CREATED"
+    ON "RESOURCE_HISTORY" ("RESOURCE_TYPE", "CREATED_AT" DESC);
+CREATE INDEX "IDX_HISTORY_OPERATION_TIME"
+    ON "RESOURCE_HISTORY" ("OPERATION", "CREATED_AT" DESC);
+CREATE INDEX "IDX_HISTORY_CREATED_BRIN"
+    ON "RESOURCE_HISTORY" USING BRIN ("CREATED_AT") WITH (pages_per_range = 64);
+
+-- -----------------------------------------------------------------------------
+-- 7. CUSTOM_EXTENSION_SEARCH_PARAMS — partial composite indexes
+-- -----------------------------------------------------------------------------
+-- Each row carries exactly ONE non-null VALUE_* column (typed by PARAM_TYPE).
+-- The original single-column indexes had no leading selectivity; these
+-- partials start with (RESOURCE_TYPE, PARAM_NAME) and only index rows of the
+-- relevant type, so each row appears in exactly one composite instead of five.
+CREATE INDEX "IDX_CUST_RT_PN_STR"
+    ON "CUSTOM_EXTENSION_SEARCH_PARAMS"
+       ("RESOURCE_TYPE", "PARAM_NAME", "VALUE_STRING")
+    WHERE "VALUE_STRING" IS NOT NULL;
+
+CREATE INDEX "IDX_CUST_RT_PN_TOKEN"
+    ON "CUSTOM_EXTENSION_SEARCH_PARAMS"
+       ("RESOURCE_TYPE", "PARAM_NAME", "VALUE_TOKEN_SYSTEM", "VALUE_TOKEN_CODE")
+    WHERE "VALUE_TOKEN_CODE" IS NOT NULL;
+
+CREATE INDEX "IDX_CUST_RT_PN_DATE"
+    ON "CUSTOM_EXTENSION_SEARCH_PARAMS"
+       ("RESOURCE_TYPE", "PARAM_NAME", "VALUE_DATE")
+    WHERE "VALUE_DATE" IS NOT NULL;
+
+CREATE INDEX "IDX_CUST_RT_PN_NUM"
+    ON "CUSTOM_EXTENSION_SEARCH_PARAMS"
+       ("RESOURCE_TYPE", "PARAM_NAME", "VALUE_NUMBER")
+    WHERE "VALUE_NUMBER" IS NOT NULL;
+
+CREATE INDEX "IDX_CUST_RT_PN_REF"
+    ON "CUSTOM_EXTENSION_SEARCH_PARAMS"
+       ("RESOURCE_TYPE", "PARAM_NAME", "VALUE_REFERENCE_TYPE", "VALUE_REFERENCE_ID")
+    WHERE "VALUE_REFERENCE_TYPE" IS NOT NULL;
+
+-- Backref: needed by the update path to find/replace all params for a resource.
+CREATE INDEX "IDX_CUST_RES_LOOKUP"
+    ON "CUSTOM_EXTENSION_SEARCH_PARAMS" ("RESOURCE_TYPE", "RESOURCE_ID");
+
+-- -----------------------------------------------------------------------------
+-- 8. Universal LAST_UPDATED B-tree on every resource table
+-- -----------------------------------------------------------------------------
+-- ~16 bytes/row; cheap. Drives _lastUpdated filter, ORDER BY _lastUpdated,
+-- per-type history feed, sync watermarks. DESC because feeds always want
+-- newest first; Postgres can scan B-trees in either direction but the leading
+-- direction match avoids a sort.
+CREATE INDEX "IDX_PATIENTTABLE_LU"                 ON "PatientTable"                 ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_OBSERVATIONTABLE_LU"             ON "ObservationTable"             ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_ENCOUNTERTABLE_LU"               ON "EncounterTable"               ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_CONDITIONTABLE_LU"               ON "ConditionTable"               ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_MEDICATIONREQUESTTABLE_LU"       ON "MedicationRequestTable"       ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_PROCEDURETABLE_LU"               ON "ProcedureTable"               ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_ALLERGYINTOLERANCETABLE_LU"      ON "AllergyIntoleranceTable"      ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_IMMUNIZATIONTABLE_LU"            ON "ImmunizationTable"            ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_DIAGNOSTICREPORTTABLE_LU"        ON "DiagnosticReportTable"        ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_CARPLANTABLE_LU"                 ON "CarePlanTable"                ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_CARETEAMTABLE_LU"                ON "CareTeamTable"                ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_GOALTABLE_LU"                    ON "GoalTable"                    ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_COVERAGETABLE_LU"                ON "CoverageTable"                ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_PRACTITIONERTABLE_LU"            ON "PractitionerTable"            ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_ORGANIZATIONTABLE_LU"            ON "OrganizationTable"            ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_LOCATIONTABLE_LU"                ON "LocationTable"                ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_TASKTABLE_LU"                    ON "TaskTable"                    ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_SERVICEREQUESTTABLE_LU"          ON "ServiceRequestTable"          ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_EPISODEOFCARETABLE_LU"           ON "EpisodeOfCareTable"           ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_MEDICATIONSTATEMENTTABLE_LU"     ON "MedicationStatementTable"     ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_MEDICATIONDISPENSETABLE_LU"      ON "MedicationDispenseTable"      ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_MEDICATIONADMINISTRATIONTABLE_LU" ON "MedicationAdministrationTable" ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_RELATEDPERSONTABLE_LU"           ON "RelatedPersonTable"           ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_APPOINTMENTTABLE_LU"             ON "AppointmentTable"             ("LAST_UPDATED" DESC);
+CREATE INDEX "IDX_DEVICETABLE_LU"                  ON "DeviceTable"                  ("LAST_UPDATED" DESC);
+
+-- -----------------------------------------------------------------------------
+-- 9. RESOURCE_JSON GIN(jsonb_path_ops) on hot resource types
+-- -----------------------------------------------------------------------------
+-- ~25-30% of body size per index. THIS is the index that replaces every
+-- LIKE-on-VARCHAR(2048)-JSON predicate. The query layer must emit @>
+-- containment instead of LIKE for it to be used (see WORK.md §5).
+--
+-- jsonb_path_ops is preferred over jsonb_ops: smaller, faster for @>, the
+-- only operator we need. (It does not support ?, ?|, ?& key-existence; if
+-- those are ever required, we add a parallel jsonb_ops index on demand.)
+--
+-- Why only the top 25? On an 8 GB box the buffer cache holds ~2 GB. Indexing
+-- 130 resource types' JSONB inflates the set of pages competing for cache
+-- without proportional benefit — Synthea + clinical workloads concentrate
+-- 99%+ of read/write volume in this list. Cold types fall back to body
+-- LIKE (or, after Phase 2, a GIN added on demand).
+CREATE INDEX "IDX_PATIENTTABLE_JSON_GIN"             ON "PatientTable"             USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_OBSERVATIONTABLE_JSON_GIN"         ON "ObservationTable"         USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_ENCOUNTERTABLE_JSON_GIN"           ON "EncounterTable"           USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_CONDITIONTABLE_JSON_GIN"           ON "ConditionTable"           USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_MEDICATIONREQUESTTABLE_JSON_GIN"   ON "MedicationRequestTable"   USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_PROCEDURETABLE_JSON_GIN"           ON "ProcedureTable"           USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_ALLERGYINTOLERANCETABLE_JSON_GIN"  ON "AllergyIntoleranceTable"  USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_IMMUNIZATIONTABLE_JSON_GIN"        ON "ImmunizationTable"        USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_DIAGNOSTICREPORTTABLE_JSON_GIN"    ON "DiagnosticReportTable"    USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_CAREPLANTABLE_JSON_GIN"            ON "CarePlanTable"            USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_CARETEAMTABLE_JSON_GIN"            ON "CareTeamTable"            USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_GOALTABLE_JSON_GIN"                ON "GoalTable"                USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_COVERAGETABLE_JSON_GIN"            ON "CoverageTable"            USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_PRACTITIONERTABLE_JSON_GIN"        ON "PractitionerTable"        USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_ORGANIZATIONTABLE_JSON_GIN"        ON "OrganizationTable"        USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_LOCATIONTABLE_JSON_GIN"            ON "LocationTable"            USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_TASKTABLE_JSON_GIN"                ON "TaskTable"                USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_SERVICEREQUESTTABLE_JSON_GIN"      ON "ServiceRequestTable"      USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_EPISODEOFCARETABLE_JSON_GIN"       ON "EpisodeOfCareTable"       USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_MEDSTATEMENTTABLE_JSON_GIN"        ON "MedicationStatementTable" USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_MEDDISPENSETABLE_JSON_GIN"         ON "MedicationDispenseTable"  USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_MEDADMINTABLE_JSON_GIN"            ON "MedicationAdministrationTable" USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_RELATEDPERSONTABLE_JSON_GIN"       ON "RelatedPersonTable"       USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_APPOINTMENTTABLE_JSON_GIN"         ON "AppointmentTable"         USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+CREATE INDEX "IDX_DEVICETABLE_JSON_GIN"              ON "DeviceTable"              USING GIN ("RESOURCE_JSON" jsonb_path_ops);
+
+
+-- -----------------------------------------------------------------------------
+-- 10. B-tree on primary date columns where GIN can't seek/order
+-- -----------------------------------------------------------------------------
+-- For the canonical clinical query "Observation where date in [...]
+-- ORDER BY date DESC". GIN returns an unsorted bitmap; sort cost is
+-- proportional to result size. A B-tree on DATE (or DATE DESC for the lead
+-- direction) avoids the sort and supports keyset pagination.
+CREATE INDEX "IDX_OBSERVATIONTABLE_DATE"           ON "ObservationTable"        ("DATE" DESC);
+CREATE INDEX "IDX_OBSERVATIONTABLE_DATE_STATUS"    ON "ObservationTable"        ("STATUS", "DATE" DESC);  -- ?status=final&date=...
+CREATE INDEX "IDX_ENCOUNTERTABLE_DATE"             ON "EncounterTable"          ("DATE" DESC);
+CREATE INDEX "IDX_PATIENTTABLE_BIRTHDATE"          ON "PatientTable"            ("BIRTHDATE");
+CREATE INDEX "IDX_CONDITIONTABLE_RECORDED_DATE"    ON "ConditionTable"          ("RECORDED_DATE" DESC);
+CREATE INDEX "IDX_CONDITIONTABLE_ONSET_DATE"       ON "ConditionTable"          ("ONSET_DATE");
+CREATE INDEX "IDX_PROCEDURETABLE_DATE"             ON "ProcedureTable"          ("DATE" DESC);
+CREATE INDEX "IDX_DIAGNOSTICREPORTTABLE_DATE"      ON "DiagnosticReportTable"   ("DATE" DESC);
+CREATE INDEX "IDX_IMMUNIZATIONTABLE_DATE"          ON "ImmunizationTable"       ("DATE" DESC);
+CREATE INDEX "IDX_MEDREQUESTTABLE_DATE"            ON "MedicationRequestTable"  ("DATE" DESC);
+CREATE INDEX "IDX_MEDADMINTABLE_EFFECTIVE"         ON "MedicationAdministrationTable" ("EFFECTIVE_TIME" DESC);
+CREATE INDEX "IDX_ALLERGYINTOLERANCETABLE_DATE"    ON "AllergyIntoleranceTable" ("DATE" DESC);
+CREATE INDEX "IDX_APPOINTMENTTABLE_DATE"           ON "AppointmentTable"        ("DATE" DESC);
+CREATE INDEX "IDX_TASKTABLE_AUTHORED_ON"           ON "TaskTable"               ("AUTHORED_ON" DESC);
+CREATE INDEX "IDX_SERVICEREQUESTTABLE_AUTHORED"    ON "ServiceRequestTable"     ("AUTHORED" DESC);
+
+-- -----------------------------------------------------------------------------
+-- 11. pg_trgm GIN on free-text search columns
+-- -----------------------------------------------------------------------------
+-- Only on columns where users genuinely type substrings (Patient.name,
+-- Practitioner.name). NOT for Observation.code, Patient.identifier, etc. —
+-- those should use body GIN @> with a structured payload. Trigram indexes
+-- are ~5x larger than B-trees and increase write cost; keep the surface small.
+CREATE INDEX "IDX_PATIENTTABLE_NAME_TRGM"
+    ON "PatientTable" USING GIN ("NAME" gin_trgm_ops);
+CREATE INDEX "IDX_PATIENTTABLE_FAMILY_TRGM"
+    ON "PatientTable" USING GIN ("FAMILY" gin_trgm_ops);
+CREATE INDEX "IDX_PRACTITIONERTABLE_NAME_TRGM"
+    ON "PractitionerTable" USING GIN ("NAME" gin_trgm_ops);
+	

--- a/miscellaneous/fhir-server/service.bal
+++ b/miscellaneous/fhir-server/service.bal
@@ -959,6 +959,36 @@ isolated function performResourcePatch(string resourceType, string id, json patc
     }
 }
 
+// WORK.md §5.3 / Phase 5: dispatch a transaction or batch Bundle to the
+// BundleHandler. The handler wraps a `transaction` Bundle in one
+// Ballerina `transaction { }` block so all entries commit atomically and
+// share a single fsync — this is the dominant Synthea ingest amortization.
+isolated function performBundleProcessing(json bundleJson) returns json|r4:OperationOutcome|r4:FHIRError {
+    log:printDebug("Bundle: Processing transaction/batch");
+    do {
+        handlers:BundleHandler bundleHandler = new handlers:BundleHandler(jdbcClient);
+        json|error result = bundleHandler.processBundle(bundleJson);
+        if result is error {
+            string errMsg = result.message();
+            log:printError(string `Bundle processing failed: ${errMsg}`);
+            if errMsg.includes("must be 'transaction' or 'batch'") || errMsg.includes("required") || errMsg.includes("Invalid Bundle") {
+                return r4:createFHIRError(errMsg, r4:ERROR, r4:INVALID, httpStatusCode = http:STATUS_BAD_REQUEST);
+            }
+            if errMsg.includes("Unresolved reference") || errMsg.includes("violates foreign key constraint") || errMsg.includes("FK_REFERENCES_TARGET") {
+                return r4:createFHIRError(errMsg, r4:ERROR, r4:INVALID, httpStatusCode = http:STATUS_UNPROCESSABLE_ENTITY);
+            }
+            if errMsg.includes("not found") {
+                return r4:createFHIRError(errMsg, r4:ERROR, r4:PROCESSING, httpStatusCode = http:STATUS_NOT_FOUND);
+            }
+            return r4:createFHIRError(errMsg, r4:ERROR, r4:PROCESSING, httpStatusCode = http:STATUS_INTERNAL_SERVER_ERROR);
+        }
+        return result;
+    } on fail error e {
+        log:printError(string `Bundle processing error: ${e.message()}`);
+        return r4:createFHIRError(string `Bundle processing failed: ${e.message()}`, r4:ERROR, r4:PROCESSING, httpStatusCode = http:STATUS_INTERNAL_SERVER_ERROR);
+    }
+}
+
 // FHIR validation error details record
 public type FHIRValidationErrorDetail record {
     *r4:FHIRErrorDetail;
@@ -1932,6 +1962,19 @@ service /fhir/r4/_export on httpListener {
     // Download export file
     resource function get download/[string jobId]/[string fileName]() returns http:Response|r4:FHIRError {
         return downloadExportFile(jobId, fileName);
+    }
+}
+
+// FHIR root service — currently only handles the system-level POST that
+// accepts a transaction or batch Bundle (WORK.md §5.3 / Phase 5). The
+// per-resource-type services bound on `/fhir/r4/{ResourceType}` are
+// unaffected because they're more-specific path matches.
+service /fhir/r4 on httpListener {
+
+    // Process a transaction or batch Bundle. Body is the Bundle as JSON;
+    // response is a transaction-response / batch-response Bundle.
+    isolated resource function post .(@http:Payload json bundleJson) returns json|r4:OperationOutcome|r4:FHIRError {
+        return performBundleProcessing(bundleJson);
     }
 }
 

--- a/miscellaneous/fhir-server/service.bal
+++ b/miscellaneous/fhir-server/service.bal
@@ -959,8 +959,7 @@ isolated function performResourcePatch(string resourceType, string id, json patc
     }
 }
 
-// WORK.md §5.3 / Phase 5: dispatch a transaction or batch Bundle to the
-// BundleHandler. The handler wraps a `transaction` Bundle in one
+// The handler wraps a `transaction` Bundle in one
 // Ballerina `transaction { }` block so all entries commit atomically and
 // share a single fsync — this is the dominant Synthea ingest amortization.
 isolated function performBundleProcessing(json bundleJson) returns json|r4:OperationOutcome|r4:FHIRError {
@@ -1966,7 +1965,7 @@ service /fhir/r4/_export on httpListener {
 }
 
 // FHIR root service — currently only handles the system-level POST that
-// accepts a transaction or batch Bundle (WORK.md §5.3 / Phase 5). The
+// accepts a transaction or batch Bundle. The
 // per-resource-type services bound on `/fhir/r4/{ResourceType}` are
 // unaffected because they're more-specific path matches.
 service /fhir/r4 on httpListener {

--- a/miscellaneous/fhir-server/tests/integration-tests.sh
+++ b/miscellaneous/fhir-server/tests/integration-tests.sh
@@ -137,6 +137,39 @@ echo ""
 # Clean the test database before starting
 echo "Cleaning test database..."
 rm -f "$SCRIPT_DIR/fhir-test-db.mv.db" "$SCRIPT_DIR/fhir-test-db.trace.db" 2>/dev/null || true
+
+# Postgres cleanup: tests use deterministic ids ("test-*"), and a soft-deleted
+# row keeps the id reserved on the next run (POST → 409). Strip those rows
+# from every *Table plus the shared history/reference/index tables. The
+# script still works on H2 (handled by the file deletes above); psql block
+# is skipped when dbType != "postgresql" or psql is unavailable.
+CONFIG_FILE="$SCRIPT_DIR/../Config.toml"
+DB_TYPE=$(grep -E '^[[:space:]]*dbType[[:space:]]*=' "$CONFIG_FILE" | head -1 | sed -E 's/.*=[[:space:]]*"([^"]+)".*/\1/')
+if [ "$DB_TYPE" = "postgresql" ] && command -v psql > /dev/null 2>&1; then
+    DB_URL=$(grep -E '^[[:space:]]*dbUrl[[:space:]]*=' "$CONFIG_FILE" | head -1 | sed -E 's/.*=[[:space:]]*"([^"]+)".*/\1/')
+    DB_USER=$(grep -E '^[[:space:]]*dbUser[[:space:]]*=' "$CONFIG_FILE" | head -1 | sed -E 's/.*=[[:space:]]*"([^"]+)".*/\1/')
+    DB_PASS=$(grep -E '^[[:space:]]*dbPassword[[:space:]]*=' "$CONFIG_FILE" | head -1 | sed -E 's/.*=[[:space:]]*"([^"]+)".*/\1/')
+    # jdbc:postgresql://host:port/db -> host, port, db
+    DB_HOST=$(echo "$DB_URL" | sed -E 's|jdbc:postgresql://([^:/]+).*|\1|')
+    DB_PORT=$(echo "$DB_URL" | sed -E 's|jdbc:postgresql://[^:/]+:?([0-9]*)/.*|\1|')
+    DB_NAME=$(echo "$DB_URL" | sed -E 's|jdbc:postgresql://[^/]+/([^?]+).*|\1|')
+    [ -z "$DB_PORT" ] && DB_PORT=5432
+    echo "Wiping 'test-*' rows from Postgres ($DB_HOST:$DB_PORT/$DB_NAME)..."
+    PGPASSWORD="$DB_PASS" psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" -v ON_ERROR_STOP=0 -q <<'SQL' > /dev/null 2>&1
+DELETE FROM "AppointmentTable"        WHERE "APPOINTMENTTABLE_ID"       LIKE 'test-%';
+DELETE FROM "PatientTable"            WHERE "PATIENTTABLE_ID"           LIKE 'test-%';
+DELETE FROM "PractitionerTable"       WHERE "PRACTITIONERTABLE_ID"      LIKE 'test-%';
+DELETE FROM "MedicationTable"         WHERE "MEDICATIONTABLE_ID"        LIKE 'test-%';
+DELETE FROM "ObservationTable"        WHERE "OBSERVATIONTABLE_ID"       LIKE 'test-%';
+DELETE FROM "MedicationRequestTable"  WHERE "MEDICATIONREQUESTTABLE_ID" LIKE 'test-%';
+DELETE FROM "ConditionTable"          WHERE "CONDITIONTABLE_ID"         LIKE 'test-%';
+DELETE FROM "RESOURCE_HISTORY"        WHERE "RESOURCE_ID"               LIKE 'test-%';
+DELETE FROM "REFERENCES"              WHERE "SOURCE_RESOURCE_ID"        LIKE 'test-%'
+                                         OR "TARGET_RESOURCE_ID"        LIKE 'test-%';
+DELETE FROM "FHIR_RESOURCE_INDEX"     WHERE "RESOURCE_ID"               LIKE 'test-%';
+SQL
+fi
+
 echo "Database cleaned"
 echo ""
 
@@ -1001,9 +1034,10 @@ else
 fi
 
 # Test 52: Search with _include and filter parameter
+# Note: test-appt-002 (only Appointment created in this run) has status=proposed
 print_test "Search Appointments by status with _include=Appointment:patient"
-RESPONSE=$(curl -s "$BASE_URL/Appointment?status=booked&_include=Appointment:patient")
-HTTP_CODE=$(curl -s -w "%{http_code}" -o /dev/null "$BASE_URL/Appointment?status=booked&_include=Appointment:patient")
+RESPONSE=$(curl -s "$BASE_URL/Appointment?status=proposed&_include=Appointment:patient")
+HTTP_CODE=$(curl -s -w "%{http_code}" -o /dev/null "$BASE_URL/Appointment?status=proposed&_include=Appointment:patient")
 if [ "$HTTP_CODE" = "200" ]; then
     # Check if response contains both match and include modes
     MATCH_MODE=$(echo "$RESPONSE" | grep -o '"mode":"match"' | wc -l)


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The FHIR server's Postgres backend had several performance and correctness gaps:
- Search on `token` and `_profile` parameters used `LIKE` over denormalized VARCHAR columns, which prevented index use and scaled poorly on large datasets.
- Write paths (create / update / patch / delete) relied on an application-level backup/restore mechanism for rollback instead of real database transactions, leaving windows where partial writes could be observed.
- There was no support for FHIR `Bundle` (transaction / batch) ingest, which blocked Synthea-style bulk loads.
- The schema lacked the indexes and side tables needed for production query patterns (GIN on JSONB, BRIN on time columns, SPIDX side tables, `FHIR_RESOURCE_INDEX`).

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

- **Native transactions** — replace the hand-rolled backup/restore plumbing in `modules/utils/transactions.bal` with Ballerina `transaction { ... check commit; } on fail` blocks in the create / update / patch / delete handlers. Each public `*WithTransaction` entry point now wraps a private `persist*` core so the bundle handler can compose them under a single outer transaction. H2 and Postgres share the same path.
- **Bundle handler** — new `modules/handlers/bundle_handler.bal` handling `Bundle.type = transaction` (atomic over all entries) and `batch` (best-effort). Mints ids for POST entries with `urn:uuid:` placeholders and rewrites cross-entry references before any DB work. Wired at `POST /fhir/r4` in `service.bal`; coexists with the per-resource-type listeners because longer paths win.
- **JSONB containment search** — rewrite the read mapper to emit `@>` containment predicates against the JSONB column for `token` (system|code) and `_profile` searches on Postgres, so the new GIN indexes are usable. H2 retains its existing LIKE path.
- **Performance schema** — extend `scripts/schema-postgresql.sql` with GIN indexes on JSONB, BRIN indexes on time columns, SPIDX side tables, and the `FHIR_RESOURCE_INDEX` upsert/tombstone table (written non-fatally from the write handlers).

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.