### PR TITLE
feat(fhir-server-go): support YAML config file alongside env vars

### DIFF
--- a/miscellaneous/fhir-server-go/README.md
+++ b/miscellaneous/fhir-server-go/README.md
@@ -60,14 +60,22 @@ docker-compose down -v
 psql -U postgres -c "CREATE USER fhir WITH PASSWORD 'fhir';"
 psql -U postgres -c "CREATE DATABASE fhirdb OWNER fhir;"
 
-# Export config (schema migrations run automatically at startup)
+# Option A — point the server at a YAML config file
+cp config.example.yaml config.yaml      # then edit as needed
+go run ./cmd/server --config ./config.yaml
+
+# Option B — drive everything from env vars (no file)
 export DATABASE_URL="postgres://fhir:fhir@localhost:5432/fhirdb?sslmode=disable"
 export SERVER_PORT=9090
 export BASE_URL=http://localhost:9090/fhir/r4
-
-# Start the server
 go run ./cmd/server
+
+# Option C — both: file for non-secrets, env for secrets
+export DB_PASSWORD="$(cat ~/.fhir-db-password)"
+go run ./cmd/server --config ./config.yaml
 ```
+
+Schema migrations run automatically at startup.
 
 The server logs a JSON line to stdout when listening:
 ```json
@@ -95,23 +103,79 @@ docker run --rm \
 
 ## 3. Configuration Reference
 
-All configuration is via environment variables. There are no config files.
+The server reads configuration from a YAML file, environment variables, or both. When the same key is set in multiple places, the higher-priority source wins:
 
-| Variable | Default | Required | Description |
+```
+env var   >   config file   >   built-in default
+```
+
+This lets you keep non-secret defaults in a checked-in `config.yaml` and inject secrets (like `DB_PASSWORD`) via environment variables at deploy time.
+
+### Specifying the config file
+
+Pass the path explicitly — there is no implicit search of the working directory, so behavior is the same on every host.
+
+```bash
+# Via CLI flag (either form):
+fhir-server --config /etc/fhir-server/config.yaml
+fhir-server -c       /etc/fhir-server/config.yaml
+
+# Or via env var (useful in containers):
+FHIR_SERVER_CONFIG=/etc/fhir-server/config.yaml fhir-server
+```
+
+If the path is set but the file is missing, malformed, or contains an unknown key, the server fails to start with a clear error.
+
+### File format
+
+YAML, with the structure below. Every key is optional — omit anything you don't need to override. See [`config.example.yaml`](config.example.yaml) for a copy-paste starting point.
+
+```yaml
+server:
+  port: 9090                                  # SERVER_PORT
+  baseUrl: http://localhost:9090/fhir/r4      # BASE_URL
+
+logging:
+  level: info                                 # LOG_LEVEL — debug | info | warn | error
+
+database:
+  # Either a full DSN ...
+  url: postgres://fhir:fhir@localhost:5432/fhirdb?sslmode=disable   # DATABASE_URL
+  # ... or individual components (ignored when `url` is set):
+  host:     localhost   # DB_HOST
+  port:     "5432"      # DB_PORT (string, in YAML)
+  user:     fhir        # DB_USER
+  password: fhir        # DB_PASSWORD
+  name:     fhirdb      # DB_NAME
+
+ig:
+  packages:                                   # IG_PACKAGES (comma-separated in env)
+    - hl7.fhir.us.core@6.1.0
+    - hl7.fhir.us.carin-bb@2.0.0
+  registryUrl: https://packages.fhir.org      # IG_REGISTRY_URL
+  forceReload: false                          # IG_FORCE_RELOAD
+  cacheDir:    .fhir-ig-cache                 # IG_CACHE_DIR
+```
+
+### Settings table
+
+| YAML key | Env var | Default | Description |
 |---|---|---|---|
-| `DATABASE_URL` | `postgres://fhir:fhir@localhost:5432/fhirdb?sslmode=disable` | Yes | Full PostgreSQL DSN. Overrides all `DB_*` variables. |
-| `DB_HOST` | `localhost` | No | PostgreSQL host (only used when `DATABASE_URL` is not set) |
-| `DB_PORT` | `5432` | No | PostgreSQL port |
-| `DB_USER` | `fhir` | No | PostgreSQL user |
-| `DB_PASSWORD` | `fhir` | No | PostgreSQL password |
-| `DB_NAME` | `fhirdb` | No | PostgreSQL database name |
-| `SERVER_PORT` | `9090` | No | HTTP listen port |
-| `BASE_URL` | `http://localhost:{PORT}/fhir/r4` | No | Canonical server base URL. Written into bundle `link` URLs and the CapabilityStatement. Must match the address clients use. |
-| `LOG_LEVEL` | `info` | No | Log verbosity: `debug`, `info`, `warn`, `error`. Logs are JSON (structured). |
-| `IG_PACKAGES` | *(empty)* | No | Comma-separated list of IG package specs to load at startup. See [Implementation Guides](#8-implementation-guides). |
-| `IG_REGISTRY_URL` | `https://packages.fhir.org` | No | FHIR package registry for resolving `name@version` specs. |
-| `IG_FORCE_RELOAD` | `false` | No | Set to `true` to re-download and re-process IGs even if already recorded in the database. |
-| `IG_CACHE_DIR` | `.fhir-ig-cache` | No | Directory for caching downloaded `.tgz` packages between restarts. |
+| `server.port` | `SERVER_PORT` | `9090` | HTTP listen port |
+| `server.baseUrl` | `BASE_URL` | `http://localhost:{port}/fhir/r4` | Canonical server base URL. Written into bundle `link` URLs and the CapabilityStatement. Must match the address clients use. |
+| `logging.level` | `LOG_LEVEL` | `info` | Log verbosity: `debug`, `info`, `warn`, `error`. Logs are JSON (structured). |
+| `database.url` | `DATABASE_URL` | *(derived)* | Full PostgreSQL DSN. When set, overrides every other `database.*` field. |
+| `database.host` | `DB_HOST` | `localhost` | PostgreSQL host (only used when `database.url` is empty) |
+| `database.port` | `DB_PORT` | `5432` | PostgreSQL port |
+| `database.user` | `DB_USER` | `fhir` | PostgreSQL user |
+| `database.password` | `DB_PASSWORD` | `fhir` | PostgreSQL password |
+| `database.name` | `DB_NAME` | `fhirdb` | PostgreSQL database name |
+| `ig.packages` | `IG_PACKAGES` | *(empty)* | List of IG package specs to load at startup. In env vars, comma-separated. See [Implementation Guides](#8-implementation-guides). |
+| `ig.registryUrl` | `IG_REGISTRY_URL` | `https://packages.fhir.org` | FHIR package registry for resolving `name@version` specs. |
+| `ig.forceReload` | `IG_FORCE_RELOAD` | `false` | Set to `true` to re-download and re-process IGs even if already recorded in the database. |
+| `ig.cacheDir` | `IG_CACHE_DIR` | `.fhir-ig-cache` | Directory for caching downloaded `.tgz` packages between restarts. |
+
+> **Secrets:** Prefer environment variables (or a secret-manager-backed env) for `DB_PASSWORD` and any other sensitive value rather than committing them to the YAML file.
 
 ---
 

--- a/miscellaneous/fhir-server-go/cmd/server/main.go
+++ b/miscellaneous/fhir-server-go/cmd/server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -30,12 +31,24 @@ func main() {
 }
 
 func run() error {
-	cfg, err := config.Load()
+	var configPath string
+	flag.StringVar(&configPath, "config", "", "Path to YAML config file (overrides FHIR_SERVER_CONFIG env var)")
+	flag.StringVar(&configPath, "c", "", "Path to YAML config file (shorthand for -config)")
+	flag.Parse()
+	if configPath == "" {
+		configPath = os.Getenv("FHIR_SERVER_CONFIG")
+	}
+
+	cfg, err := config.LoadFromPath(configPath)
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
 
 	setupLogging(cfg.LogLevel)
+
+	if configPath != "" {
+		slog.Info("loaded config file", "path", configPath)
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/miscellaneous/fhir-server-go/config.example.yaml
+++ b/miscellaneous/fhir-server-go/config.example.yaml
@@ -1,0 +1,37 @@
+# FHIR Server — example configuration
+#
+# All keys are optional. Anything omitted falls back to the matching
+# environment variable, and then to the built-in default.
+#
+# Precedence (highest wins): env var > this file > default.
+# Point the server at this file with:
+#     fhir-server --config /path/to/config.yaml
+#   or
+#     FHIR_SERVER_CONFIG=/path/to/config.yaml fhir-server
+
+server:
+  port: 9090
+  baseUrl: http://localhost:9090/fhir/r4
+
+logging:
+  # One of: debug, info, warn, error
+  level: info
+
+database:
+  # Either supply a full DSN ...
+  url: postgres://fhir:fhir@localhost:5432/fhirdb?sslmode=disable
+  # ... or the individual components (ignored when `url` is set):
+  # host: localhost
+  # port: "5432"
+  # user: fhir
+  # password: fhir
+  # name: fhirdb
+
+ig:
+  # Implementation guides to load at startup.
+  packages:
+    - hl7.fhir.us.core@6.1.0
+    # - hl7.fhir.us.carin-bb@2.0.0
+  registryUrl: https://packages.fhir.org
+  forceReload: false
+  cacheDir: .fhir-ig-cache

--- a/miscellaneous/fhir-server-go/go.mod
+++ b/miscellaneous/fhir-server-go/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0
 	golang.org/x/sync v0.19.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -64,5 +65,4 @@ require (
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/miscellaneous/fhir-server-go/internal/config/config.go
+++ b/miscellaneous/fhir-server-go/internal/config/config.go
@@ -1,14 +1,25 @@
 package config
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/url"
 	"os"
 	"strconv"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
+// Config is the resolved server configuration consumed by the rest of the
+// application. Values are merged from (in order of precedence, highest first):
+//
+//  1. Environment variables
+//  2. The YAML configuration file (if one is specified)
+//  3. Built-in defaults
 type Config struct {
 	DatabaseURL   string
 	Port          int
@@ -20,58 +31,172 @@ type Config struct {
 	IGCacheDir    string   // local .tgz cache dir (default: .fhir-ig-cache)
 }
 
+// FileConfig is the on-disk YAML schema. Each field is optional — anything
+// not specified falls through to the env var, then to the built-in default.
+type FileConfig struct {
+	Server struct {
+		Port    int    `yaml:"port"`
+		BaseURL string `yaml:"baseUrl"`
+	} `yaml:"server"`
+
+	Logging struct {
+		Level string `yaml:"level"`
+	} `yaml:"logging"`
+
+	Database struct {
+		URL      string `yaml:"url"`
+		Host     string `yaml:"host"`
+		Port     string `yaml:"port"`
+		User     string `yaml:"user"`
+		Password string `yaml:"password"`
+		Name     string `yaml:"name"`
+	} `yaml:"database"`
+
+	IG struct {
+		Packages    []string `yaml:"packages"`
+		RegistryURL string   `yaml:"registryUrl"`
+		ForceReload *bool    `yaml:"forceReload"` // pointer so absence is distinguishable from `false`
+		CacheDir    string   `yaml:"cacheDir"`
+	} `yaml:"ig"`
+}
+
+// Load reads configuration using the env-var-based discovery path. The
+// optional config file location is taken from FHIR_SERVER_CONFIG.
+//
+// Callers that parse CLI flags should use LoadFromPath instead.
 func Load() (*Config, error) {
-	dbURL := os.Getenv("DATABASE_URL")
-	if dbURL == "" {
-		host := getenv("DB_HOST", "localhost")
-		port := getenv("DB_PORT", "5432")
-		user := getenv("DB_USER", "fhir")
-		pass := getenv("DB_PASSWORD", "fhir")
-		name := getenv("DB_NAME", "fhirdb")
-		u := &url.URL{
-			Scheme:   "postgres",
-			User:     url.UserPassword(user, pass),
-			Host:     net.JoinHostPort(host, port),
-			Path:     "/" + name,
-			RawQuery: "sslmode=disable",
-		}
-		dbURL = u.String()
-	}
+	return LoadFromPath(os.Getenv("FHIR_SERVER_CONFIG"))
+}
 
-	serverPort := 9090
-	if p := os.Getenv("SERVER_PORT"); p != "" {
-		n, err := strconv.Atoi(p)
+// LoadFromPath reads configuration, optionally seeded from a YAML file at the
+// given path. An empty path means "no config file" — only env vars + defaults
+// are applied. A non-empty path that cannot be read or parsed returns an
+// error; unknown YAML keys are also rejected so typos surface loudly.
+func LoadFromPath(path string) (*Config, error) {
+	var fc FileConfig
+	if path != "" {
+		data, err := os.ReadFile(path)
 		if err != nil {
-			return nil, fmt.Errorf("invalid SERVER_PORT: %w", err)
+			return nil, fmt.Errorf("read config file %q: %w", path, err)
 		}
-		serverPort = n
+		dec := yaml.NewDecoder(bytes.NewReader(data))
+		dec.KnownFields(true)
+		if err := dec.Decode(&fc); err != nil && !errors.Is(err, io.EOF) {
+			// io.EOF means the file was empty / whitespace-only — that's fine,
+			// we just fall through to env vars + defaults.
+			return nil, fmt.Errorf("parse config file %q: %w", path, err)
+		}
+	}
+	return resolve(&fc)
+}
+
+// resolve materializes a Config from a (possibly empty) FileConfig, layering
+// env vars on top and falling back to defaults.
+func resolve(fc *FileConfig) (*Config, error) {
+	dbURL, err := resolveDatabaseURL(fc)
+	if err != nil {
+		return nil, err
 	}
 
-	// IG_PACKAGES: comma-separated list, e.g. "hl7.fhir.us.core@6.1.0,hl7.fhir.us.carin-bb@2.0.0"
-	var igPackages []string
-	if raw := os.Getenv("IG_PACKAGES"); raw != "" {
-		for _, p := range strings.Split(raw, ",") {
-			if p = strings.TrimSpace(p); p != "" {
-				igPackages = append(igPackages, p)
-			}
-		}
+	serverPort, err := resolveServerPort(fc)
+	if err != nil {
+		return nil, err
+	}
+
+	baseURL := pick(os.Getenv("BASE_URL"), fc.Server.BaseURL, fmt.Sprintf("http://localhost:%d/fhir/r4", serverPort))
+	logLevel := pick(os.Getenv("LOG_LEVEL"), fc.Logging.Level, "info")
+
+	igPackages := resolveIGPackages(fc)
+	igRegistry := pick(os.Getenv("IG_REGISTRY_URL"), fc.IG.RegistryURL, "https://packages.fhir.org")
+	igCacheDir := pick(os.Getenv("IG_CACHE_DIR"), fc.IG.CacheDir, ".fhir-ig-cache")
+
+	igForceReload := false
+	if fc.IG.ForceReload != nil {
+		igForceReload = *fc.IG.ForceReload
+	}
+	if v := os.Getenv("IG_FORCE_RELOAD"); v != "" {
+		igForceReload = strings.EqualFold(v, "true")
 	}
 
 	return &Config{
 		DatabaseURL:   dbURL,
 		Port:          serverPort,
-		BaseURL:       getenv("BASE_URL", fmt.Sprintf("http://localhost:%d/fhir/r4", serverPort)),
-		LogLevel:      getenv("LOG_LEVEL", "info"),
+		BaseURL:       baseURL,
+		LogLevel:      logLevel,
 		IGPackages:    igPackages,
-		IGRegistryURL: getenv("IG_REGISTRY_URL", "https://packages.fhir.org"),
-		IGForceReload: os.Getenv("IG_FORCE_RELOAD") == "true",
-		IGCacheDir:    getenv("IG_CACHE_DIR", ".fhir-ig-cache"),
+		IGRegistryURL: igRegistry,
+		IGForceReload: igForceReload,
+		IGCacheDir:    igCacheDir,
 	}, nil
 }
 
-func getenv(key, def string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
+func resolveDatabaseURL(fc *FileConfig) (string, error) {
+	if v := os.Getenv("DATABASE_URL"); v != "" {
+		return v, nil
 	}
-	return def
+	if fc.Database.URL != "" {
+		return fc.Database.URL, nil
+	}
+	host := pick(os.Getenv("DB_HOST"), fc.Database.Host, "localhost")
+	port := pick(os.Getenv("DB_PORT"), fc.Database.Port, "5432")
+	user := pick(os.Getenv("DB_USER"), fc.Database.User, "fhir")
+	pass := pick(os.Getenv("DB_PASSWORD"), fc.Database.Password, "fhir")
+	name := pick(os.Getenv("DB_NAME"), fc.Database.Name, "fhirdb")
+	u := &url.URL{
+		Scheme:   "postgres",
+		User:     url.UserPassword(user, pass),
+		Host:     net.JoinHostPort(host, port),
+		Path:     "/" + name,
+		RawQuery: "sslmode=disable",
+	}
+	return u.String(), nil
+}
+
+func resolveServerPort(fc *FileConfig) (int, error) {
+	if v := os.Getenv("SERVER_PORT"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return 0, fmt.Errorf("invalid SERVER_PORT: %w", err)
+		}
+		return n, nil
+	}
+	if fc.Server.Port != 0 {
+		return fc.Server.Port, nil
+	}
+	return 9090, nil
+}
+
+func resolveIGPackages(fc *FileConfig) []string {
+	// IG_PACKAGES is comma-separated: "hl7.fhir.us.core@6.1.0,hl7.fhir.us.carin-bb@2.0.0".
+	// A non-empty value fully replaces the file's list. Empty / unset → fall back to file.
+	if raw := os.Getenv("IG_PACKAGES"); raw != "" {
+		var pkgs []string
+		for _, p := range strings.Split(raw, ",") {
+			if p = strings.TrimSpace(p); p != "" {
+				pkgs = append(pkgs, p)
+			}
+		}
+		return pkgs
+	}
+	if len(fc.IG.Packages) > 0 {
+		// Defensive copy + trim, so the resolved Config isn't aliased to FileConfig.
+		out := make([]string, 0, len(fc.IG.Packages))
+		for _, p := range fc.IG.Packages {
+			if p = strings.TrimSpace(p); p != "" {
+				out = append(out, p)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// pick returns the first non-empty value. Useful for env > file > default chains.
+func pick(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }

--- a/miscellaneous/fhir-server-go/internal/config/config_test.go
+++ b/miscellaneous/fhir-server-go/internal/config/config_test.go
@@ -187,6 +187,7 @@ func clearIGEnv(t *testing.T) {
 		"DATABASE_URL", "DB_HOST", "DB_PORT", "DB_USER", "DB_PASSWORD", "DB_NAME",
 		"SERVER_PORT", "BASE_URL", "LOG_LEVEL",
 		"IG_PACKAGES", "IG_REGISTRY_URL", "IG_FORCE_RELOAD", "IG_CACHE_DIR",
+		"FHIR_SERVER_CONFIG",
 	} {
 		t.Setenv(k, "")
 	}

--- a/miscellaneous/fhir-server-go/internal/config/file_test.go
+++ b/miscellaneous/fhir-server-go/internal/config/file_test.go
@@ -1,0 +1,291 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wso2/open-healthcare-fhir-server-go/internal/config"
+)
+
+// writeConfig writes a YAML config to a temp file and returns its path.
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+	return path
+}
+
+func TestLoadFromPath_EmptyPath_UsesDefaults(t *testing.T) {
+	clearIGEnv(t)
+
+	cfg, err := config.LoadFromPath("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Port != 9090 {
+		t.Errorf("Port: got %d, want 9090", cfg.Port)
+	}
+	if cfg.LogLevel != "info" {
+		t.Errorf("LogLevel: got %q, want info", cfg.LogLevel)
+	}
+	if cfg.IGRegistryURL != "https://packages.fhir.org" {
+		t.Errorf("IGRegistryURL: got %q", cfg.IGRegistryURL)
+	}
+}
+
+func TestLoadFromPath_FullFile(t *testing.T) {
+	clearIGEnv(t)
+
+	path := writeConfig(t, `
+server:
+  port: 8443
+  baseUrl: https://fhir.example.com/r4
+
+logging:
+  level: debug
+
+database:
+  url: postgres://u:p@db.example.com:5432/fhir?sslmode=require
+
+ig:
+  packages:
+    - hl7.fhir.us.core@6.1.0
+    - hl7.fhir.us.carin-bb@2.0.0
+  registryUrl: https://registry.example.com
+  forceReload: true
+  cacheDir: /var/cache/fhir-ig
+`)
+
+	cfg, err := config.LoadFromPath(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Port != 8443 {
+		t.Errorf("Port: got %d, want 8443", cfg.Port)
+	}
+	if cfg.BaseURL != "https://fhir.example.com/r4" {
+		t.Errorf("BaseURL: got %q", cfg.BaseURL)
+	}
+	if cfg.LogLevel != "debug" {
+		t.Errorf("LogLevel: got %q, want debug", cfg.LogLevel)
+	}
+	if cfg.DatabaseURL != "postgres://u:p@db.example.com:5432/fhir?sslmode=require" {
+		t.Errorf("DatabaseURL: got %q", cfg.DatabaseURL)
+	}
+	if len(cfg.IGPackages) != 2 || cfg.IGPackages[0] != "hl7.fhir.us.core@6.1.0" {
+		t.Errorf("IGPackages: got %v", cfg.IGPackages)
+	}
+	if cfg.IGRegistryURL != "https://registry.example.com" {
+		t.Errorf("IGRegistryURL: got %q", cfg.IGRegistryURL)
+	}
+	if !cfg.IGForceReload {
+		t.Error("IGForceReload: want true from file")
+	}
+	if cfg.IGCacheDir != "/var/cache/fhir-ig" {
+		t.Errorf("IGCacheDir: got %q", cfg.IGCacheDir)
+	}
+}
+
+func TestLoadFromPath_PartialFile_FallsBackToDefaults(t *testing.T) {
+	clearIGEnv(t)
+
+	// Only set port; everything else should fall through to defaults.
+	path := writeConfig(t, "server:\n  port: 7777\n")
+
+	cfg, err := config.LoadFromPath(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Port != 7777 {
+		t.Errorf("Port: got %d, want 7777", cfg.Port)
+	}
+	// BaseURL default should embed the port from the file.
+	if cfg.BaseURL != "http://localhost:7777/fhir/r4" {
+		t.Errorf("BaseURL: got %q", cfg.BaseURL)
+	}
+	if cfg.LogLevel != "info" {
+		t.Errorf("LogLevel: got %q, want default info", cfg.LogLevel)
+	}
+	if cfg.IGCacheDir != ".fhir-ig-cache" {
+		t.Errorf("IGCacheDir: got %q, want default", cfg.IGCacheDir)
+	}
+}
+
+func TestLoadFromPath_DatabaseFromComponents(t *testing.T) {
+	clearIGEnv(t)
+
+	path := writeConfig(t, `
+database:
+  host: db.internal
+  port: "6432"
+  user: app
+  password: secret
+  name: clinical
+`)
+
+	cfg, err := config.LoadFromPath(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "postgres://app:secret@db.internal:6432/clinical?sslmode=disable"
+	if cfg.DatabaseURL != want {
+		t.Errorf("DatabaseURL:\n got  %q\n want %q", cfg.DatabaseURL, want)
+	}
+}
+
+func TestLoadFromPath_EnvOverridesFile(t *testing.T) {
+	clearIGEnv(t)
+
+	path := writeConfig(t, `
+server:
+  port: 8080
+logging:
+  level: warn
+database:
+  url: postgres://file/db
+ig:
+  packages: [hl7.fhir.us.core@6.1.0]
+  forceReload: false
+`)
+
+	t.Setenv("SERVER_PORT", "9999")
+	t.Setenv("LOG_LEVEL", "error")
+	t.Setenv("DATABASE_URL", "postgres://env/db")
+	t.Setenv("IG_FORCE_RELOAD", "true")
+
+	cfg, err := config.LoadFromPath(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Port != 9999 {
+		t.Errorf("Port: env should win, got %d", cfg.Port)
+	}
+	if cfg.LogLevel != "error" {
+		t.Errorf("LogLevel: env should win, got %q", cfg.LogLevel)
+	}
+	if cfg.DatabaseURL != "postgres://env/db" {
+		t.Errorf("DatabaseURL: env should win, got %q", cfg.DatabaseURL)
+	}
+	if !cfg.IGForceReload {
+		t.Error("IGForceReload: env true should win over file false")
+	}
+}
+
+func TestLoadFromPath_EnvIGPackagesReplacesFileList(t *testing.T) {
+	clearIGEnv(t)
+
+	path := writeConfig(t, `
+ig:
+  packages:
+    - file-only@1.0.0
+`)
+
+	t.Setenv("IG_PACKAGES", "env-pkg@2.0.0,other@3.0.0")
+
+	cfg, err := config.LoadFromPath(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.IGPackages) != 2 {
+		t.Fatalf("expected 2 packages from env, got %v", cfg.IGPackages)
+	}
+	if cfg.IGPackages[0] != "env-pkg@2.0.0" || cfg.IGPackages[1] != "other@3.0.0" {
+		t.Errorf("env IG_PACKAGES should fully replace file list, got %v", cfg.IGPackages)
+	}
+}
+
+func TestLoadFromPath_FileMissing(t *testing.T) {
+	clearIGEnv(t)
+
+	_, err := config.LoadFromPath("/nonexistent/does-not-exist.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !strings.Contains(err.Error(), "read config file") {
+		t.Errorf("error message should mention reading the file, got: %v", err)
+	}
+}
+
+func TestLoadFromPath_InvalidYAML(t *testing.T) {
+	clearIGEnv(t)
+
+	path := writeConfig(t, "server:\n  port: [not, a, number\n")
+
+	_, err := config.LoadFromPath(path)
+	if err == nil {
+		t.Fatal("expected error for malformed YAML")
+	}
+	if !strings.Contains(err.Error(), "parse config file") {
+		t.Errorf("error message should mention parsing, got: %v", err)
+	}
+}
+
+func TestLoadFromPath_UnknownFieldRejected(t *testing.T) {
+	clearIGEnv(t)
+
+	// Typo: `baseURL` vs `baseUrl` — strict mode should catch this so users
+	// don't silently get the default.
+	path := writeConfig(t, "server:\n  baseURL: https://fhir.example.com\n")
+
+	_, err := config.LoadFromPath(path)
+	if err == nil {
+		t.Fatal("expected strict-mode rejection of unknown YAML field")
+	}
+}
+
+func TestLoad_RespectsFHIRServerConfigEnv(t *testing.T) {
+	clearIGEnv(t)
+
+	path := writeConfig(t, "server:\n  port: 4242\n")
+	t.Setenv("FHIR_SERVER_CONFIG", path)
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Port != 4242 {
+		t.Errorf("Load() should honour FHIR_SERVER_CONFIG path, got Port=%d", cfg.Port)
+	}
+}
+
+func TestLoadFromPath_EmptyFile(t *testing.T) {
+	clearIGEnv(t)
+
+	path := writeConfig(t, "")
+
+	cfg, err := config.LoadFromPath(path)
+	if err != nil {
+		t.Fatalf("empty file should parse to defaults, got: %v", err)
+	}
+	if cfg.Port != 9090 {
+		t.Errorf("Port: got %d, want default 9090", cfg.Port)
+	}
+}
+
+func TestLoadFromPath_IGPackagesWhitespaceTrimmed(t *testing.T) {
+	clearIGEnv(t)
+
+	path := writeConfig(t, `
+ig:
+  packages:
+    - "  hl7.fhir.us.core@6.1.0  "
+    - ""
+    - "hl7.fhir.us.carin-bb@2.0.0"
+`)
+
+	cfg, err := config.LoadFromPath(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.IGPackages) != 2 {
+		t.Fatalf("expected 2 non-empty packages, got %v", cfg.IGPackages)
+	}
+	if cfg.IGPackages[0] != "hl7.fhir.us.core@6.1.0" {
+		t.Errorf("pkg[0] should be trimmed, got %q", cfg.IGPackages[0])
+	}
+}


### PR DESCRIPTION
## Summary

Adds YAML config-file support to `fhir-server-go` so deployments aren't limited to env vars. Useful for OpenChoreo / Kubernetes setups where most settings live in a ConfigMap and only secrets come from env.

- New `--config` / `-c` flag (plus `FHIR_SERVER_CONFIG` env var) selects the file
- Precedence: **env var > config file > built-in default** — non-secret defaults can live in a checked-in `config.yaml`, secrets stay in env
- Strict YAML parsing (unknown keys are rejected) so typos like `baseURL` vs `baseUrl` fail loudly at startup
- `gopkg.in/yaml.v3` was already a transitive dep via testcontainers; just promoted to a direct require

### Example

```yaml
server:
  port: 9090
  baseUrl: http://localhost:9090/fhir/r4
logging:
  level: info
database:
  url: postgres://fhir:fhir@localhost:5432/fhirdb?sslmode=disable
ig:
  packages:
    - hl7.fhir.us.core@6.1.0
  registryUrl: https://packages.fhir.org
  forceReload: false
  cacheDir: .fhir-ig-cache
```

```bash
fhir-server --config /etc/fhir-server/config.yaml
# or
FHIR_SERVER_CONFIG=/etc/fhir-server/config.yaml fhir-server
```

## Files

- `internal/config/config.go` — `FileConfig` schema, `LoadFromPath(path)`, layered resolution
- `internal/config/file_test.go` — 12 new tests
- `cmd/server/main.go` — `--config` / `-c` flag, env fallback
- `config.example.yaml` — annotated starting-point file
- `README.md` — replaces env-only section with file + env reference, YAML ↔ env mapping table, three-option run snippet
- `go.mod` — `gopkg.in/yaml.v3` promoted to direct dependency

`Load()` and all of the existing `DATABASE_URL` / `SERVER_PORT` / `IG_PACKAGES` / ... env vars continue to work unchanged, so this is fully backward compatible with current deployments.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` all clean
- [x] 25 config tests pass (13 pre-existing + 12 new) — defaults, full file, partial file, empty file, DB-from-components, env-overrides-file (per-key + IG packages), missing file, malformed YAML, unknown-key rejection, whitespace trimming, `FHIR_SERVER_CONFIG` honoured by `Load()`
- [x] Binary verified: `--help` shows the new flag; `--config /nonexistent.yaml` fails with a clear error
- [ ] Reviewer to spot-check the YAML ↔ env table in the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)