### PR TITLE
fix(fhir-server-go): bump go-chi/chi to v5.2.5 (GHSA-vrw8-fxc6-2r93)

### DIFF
--- a/miscellaneous/fhir-server-go/go.mod
+++ b/miscellaneous/fhir-server-go/go.mod
@@ -3,7 +3,7 @@ module github.com/wso2/open-healthcare-fhir-server-go
 go 1.25.0
 
 require (
-	github.com/go-chi/chi/v5 v5.1.0
+	github.com/go-chi/chi/v5 v5.2.5
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0

--- a/miscellaneous/fhir-server-go/go.sum
+++ b/miscellaneous/fhir-server-go/go.sum
@@ -35,8 +35,8 @@ github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/go-chi/chi/v5 v5.1.0 h1:acVI1TYaD+hhedDJ3r54HyA6sExp3HfXq7QWEEY/xMw=
-github.com/go-chi/chi/v5 v5.1.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
## Summary

Resolves Dependabot alert [#1](https://github.com/wso2/open-healthcare-prebuilt-services/security/dependabot/1) — a medium-severity **open redirect via Host header injection** in `github.com/go-chi/chi/v5`.

- **Advisory:** [GHSA-vrw8-fxc6-2r93](https://github.com/advisories/GHSA-vrw8-fxc6-2r93)
- **CWE:** [CWE-601 — URL Redirection to Untrusted Site](https://cwe.mitre.org/data/definitions/601.html)
- **CVSS v4:** 5.1 (medium)
- **Vulnerable range:** `<= 5.2.1` — **Fixed in:** `5.2.2`
- **Bump:** `v5.1.0` → `v5.2.5` (latest patch on the 5.2.x line; smallest version range that addresses the issue while picking up subsequent patch fixes)

### Root cause

`middleware.RedirectSlashes` constructs the redirect URL using the request `Host` header, which is attacker-controllable:

```bash
curl -iL -H "Host: example.com" http://localhost:8080/test/
# → 301 to https://example.com/test/   (attacker-chosen host)
```

### Exposure in this repo

`miscellaneous/fhir-server-go/internal/handler/router.go` does **not** mount `RedirectSlashes`:

```go
r.Use(middleware.RealIP)
r.Use(middleware.RequestID)
r.Use(middleware.Recoverer)
```

So the issue is **not exploitable today**. This bump is defense-in-depth and clears the Dependabot alert; future code adding `RedirectSlashes` would be safe by default after this change.

### Why intra-minor (5.2.5) instead of 5.3.0

Keeps the change minimal and security-only — no minor-version surface area to review. 5.2.5 is the latest patch on the 5.2 line.

## Files changed

- `miscellaneous/fhir-server-go/go.mod` — `chi/v5` bumped 5.1.0 → 5.2.5
- `miscellaneous/fhir-server-go/go.sum` — checksums refreshed

No source code changes.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all unit tests pass (config, fhirpath, handler, ig, searchparam, store)
- [x] `grep -rn RedirectSlashes` confirms the vulnerable middleware is not referenced anywhere in the codebase
- [ ] Reviewer to confirm Dependabot alert #1 auto-closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)