### PR TITLE
feat(fhir-server-go): system-level transaction/batch Bundle endpoint

### DIFF
--- a/miscellaneous/fhir-server-go/README.md
+++ b/miscellaneous/fhir-server-go/README.md
@@ -345,6 +345,7 @@ Track which IG packages have been loaded (for skip-on-restart) and which profile
 | Method | Path | Status | Description |
 |---|---|---|---|
 | `GET` | `/metadata` | 200 | CapabilityStatement |
+| `POST` | `/` (FHIR base) | 200, 400, 4xx | Process a `transaction` / `batch` Bundle |
 | `GET` | `/{type}/{id}` | 200, 404, 410 | Read resource (410 if soft-deleted) |
 | `GET` | `/{type}/{id}/_history/{vid}` | 200, 400, 404 | Read specific version |
 | `POST` | `/{type}` | 201 | Create resource |
@@ -455,6 +456,63 @@ curl -X DELETE http://localhost:9090/fhir/r4/Patient/550e8400-e29b-41d4-a716-446
 ```
 
 The resource row is soft-deleted (`is_deleted = TRUE`). Subsequent reads return **410 Gone**.
+
+#### Transaction / Batch Bundle
+
+`POST` a `Bundle` to the FHIR base (`/fhir/r4`). Each `entry.request` carries the
+`method` and `url` the entry would have used as a standalone interaction.
+
+```bash
+curl -X POST http://localhost:9090/fhir/r4 \
+  -H 'Content-Type: application/fhir+json' \
+  -d '{
+    "resourceType": "Bundle",
+    "type": "transaction",
+    "entry": [
+      {
+        "fullUrl": "urn:uuid:pat-1",
+        "resource": { "resourceType": "Patient", "name": [{"family": "Smith"}] },
+        "request": { "method": "POST", "url": "Patient" }
+      },
+      {
+        "resource": {
+          "resourceType": "Observation", "status": "final",
+          "code": { "text": "heart-rate" },
+          "subject": { "reference": "urn:uuid:pat-1" }
+        },
+        "request": { "method": "POST", "url": "Observation" }
+      }
+    ]
+  }'
+```
+
+The response is a `transaction-response` Bundle whose entries carry
+`response.status` / `response.location` / `response.etag`.
+
+**Semantics**
+
+| Bundle type | Atomicity | On entry failure |
+|---|---|---|
+| `transaction` | All entries commit in a **single DB transaction** | Whole Bundle rolls back; a single `OperationOutcome` is returned with the failing entry's status |
+| `batch` | Each entry runs **independently** | Only that entry fails (its `response` carries an `OperationOutcome`); siblings are unaffected; overall status is `200` |
+
+Supported per-entry methods: `POST`, `PUT`, `PATCH` (JSON Merge Patch), `DELETE`, `GET`.
+
+- **Reference resolution** — within a `transaction`, `urn:uuid:` (and absolute-URL)
+  references between entries are rewritten to the server-assigned `Type/id` before
+  persisting. `POST` entries are processed in FHIR verb order (DELETE → POST →
+  PUT/PATCH → GET) so references resolve regardless of entry order.
+- **Conditional create** — `entry.request.ifNoneExist` (a search query). If it
+  matches one existing resource the create is skipped and the entry resolves to it;
+  more than one match is a `412`.
+- **Conditional update / delete** — a `PUT`/`DELETE` whose `request.url` is a search
+  query (e.g. `Patient?identifier=urn:cond|abc`). One match updates/deletes it;
+  zero matches creates (PUT) or no-ops (DELETE); multiple matches is a `412`.
+- **Optimistic locking** — `entry.request.ifMatch` (e.g. `W/"2"`) is honoured on `PUT`.
+
+> **Note:** `GET` search entries inside a `transaction` read the *committed* snapshot
+> and do not observe not-yet-committed writes from earlier entries in the same Bundle.
+> Instance reads (`GET Type/id`) do observe them.
 
 #### Search (GET)
 

--- a/miscellaneous/fhir-server-go/internal/handler/bundle.go
+++ b/miscellaneous/fhir-server-go/internal/handler/bundle.go
@@ -45,6 +45,8 @@ func (h *fhirHandler) bundle(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var be *store.BundleError
 		if errors.As(err, &be) {
+			slog.Error("bundle execution failed", "bundleType", bundleType,
+				"entryIndex", be.EntryIndex, "status", be.HTTPStatus, "err", be.Diagnostics)
 			diag := be.Diagnostics
 			if be.EntryIndex >= 0 {
 				diag = fmt.Sprintf("entry[%d]: %s", be.EntryIndex, be.Diagnostics)
@@ -52,16 +54,26 @@ func (h *fhirHandler) bundle(w http.ResponseWriter, r *http.Request) {
 			operationOutcome(w, be.HTTPStatus, "error", be.Code, diag)
 			return
 		}
+		slog.Error("bundle execution failed", "bundleType", bundleType, "err", err)
 		operationOutcome(w, http.StatusInternalServerError, "error", "exception", err.Error())
 		return
 	}
 
 	// Keep the in-memory SearchParameter registry in sync with any custom
-	// SearchParameters written by the Bundle, mirroring the single-resource path.
+	// SearchParameters written by the Bundle, mirroring the single-resource path:
+	// create/update re-sync the definition, delete removes it.
 	for _, res := range results {
-		if res.Resource != nil {
-			if rt, _ := res.Resource["resourceType"].(string); rt == "SearchParameter" {
+		if res.ResourceType != "SearchParameter" {
+			continue
+		}
+		switch res.Method {
+		case "POST", "PUT", "PATCH":
+			if res.Resource != nil {
 				_ = h.store.SyncSearchParameter(r.Context(), res.Resource)
+			}
+		case "DELETE":
+			if res.ID != "" {
+				_ = h.store.DeleteSearchParameter(r.Context(), res.ID)
 			}
 		}
 	}

--- a/miscellaneous/fhir-server-go/internal/handler/bundle.go
+++ b/miscellaneous/fhir-server-go/internal/handler/bundle.go
@@ -1,0 +1,162 @@
+package handler
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/wso2/open-healthcare-fhir-server-go/internal/store"
+)
+
+// bundle handles POST /fhir/r4 — a system-level transaction or batch Bundle.
+func (h *fhirHandler) bundle(w http.ResponseWriter, r *http.Request) {
+	if !requireFHIRContent(w, r) {
+		return
+	}
+
+	body, err := readBody(r)
+	if err != nil {
+		operationOutcome(w, http.StatusBadRequest, "error", "invalid", "invalid JSON: "+err.Error())
+		return
+	}
+
+	if rt, _ := body["resourceType"].(string); rt != "Bundle" {
+		operationOutcome(w, http.StatusBadRequest, "error", "invalid",
+			"request body must be a Bundle resource")
+		return
+	}
+
+	bundleType, _ := body["type"].(string)
+	if bundleType != "transaction" && bundleType != "batch" {
+		operationOutcome(w, http.StatusBadRequest, "error", "value",
+			fmt.Sprintf("Bundle.type must be 'transaction' or 'batch', got %q", bundleType))
+		return
+	}
+
+	entries, perr := parseBundleEntries(body)
+	if perr != "" {
+		operationOutcome(w, http.StatusBadRequest, "error", "value", perr)
+		return
+	}
+
+	results, err := h.store.ExecuteBundle(r.Context(), bundleType, h.baseURL, entries)
+	if err != nil {
+		var be *store.BundleError
+		if errors.As(err, &be) {
+			diag := be.Diagnostics
+			if be.EntryIndex >= 0 {
+				diag = fmt.Sprintf("entry[%d]: %s", be.EntryIndex, be.Diagnostics)
+			}
+			operationOutcome(w, be.HTTPStatus, "error", be.Code, diag)
+			return
+		}
+		operationOutcome(w, http.StatusInternalServerError, "error", "exception", err.Error())
+		return
+	}
+
+	// Keep the in-memory SearchParameter registry in sync with any custom
+	// SearchParameters written by the Bundle, mirroring the single-resource path.
+	for _, res := range results {
+		if res.Resource != nil {
+			if rt, _ := res.Resource["resourceType"].(string); rt == "SearchParameter" {
+				_ = h.store.SyncSearchParameter(r.Context(), res.Resource)
+			}
+		}
+	}
+
+	responseType := "transaction-response"
+	if bundleType == "batch" {
+		responseType = "batch-response"
+	}
+	writeJSON(w, http.StatusOK, h.buildBundleResponse(responseType, results))
+}
+
+// buildBundleResponse assembles the transaction-response / batch-response Bundle.
+func (h *fhirHandler) buildBundleResponse(responseType string, results []store.BundleEntryResult) map[string]any {
+	entries := make([]any, 0, len(results))
+	for _, res := range results {
+		response := map[string]any{"status": res.Status}
+		if res.Location != "" {
+			response["location"] = h.absoluteLocation(res.Location)
+		}
+		if res.ETag != "" {
+			response["etag"] = res.ETag
+		}
+		if res.Outcome != nil {
+			response["outcome"] = res.Outcome
+		}
+
+		entry := map[string]any{"response": response}
+		if res.Resource != nil {
+			entry["resource"] = res.Resource
+		}
+		entries = append(entries, entry)
+	}
+
+	return map[string]any{
+		"resourceType": "Bundle",
+		"type":         responseType,
+		"entry":        entries,
+	}
+}
+
+// absoluteLocation turns a relative "Type/id/_history/v" location into an
+// absolute URL under the server base.
+func (h *fhirHandler) absoluteLocation(loc string) string {
+	if strings.Contains(loc, "://") {
+		return loc
+	}
+	return strings.TrimRight(h.baseURL, "/") + "/" + strings.TrimLeft(loc, "/")
+}
+
+// parseBundleEntries converts the raw Bundle.entry array into typed store
+// requests. It returns a non-empty error string on a malformed Bundle.
+func parseBundleEntries(bundle map[string]any) ([]store.BundleEntryRequest, string) {
+	rawEntries, ok := bundle["entry"].([]any)
+	if !ok {
+		// An empty Bundle is valid — nothing to process.
+		return nil, ""
+	}
+
+	entries := make([]store.BundleEntryRequest, 0, len(rawEntries))
+	for i, raw := range rawEntries {
+		entryMap, ok := raw.(map[string]any)
+		if !ok {
+			return nil, fmt.Sprintf("entry[%d] is not an object", i)
+		}
+
+		req, ok := entryMap["request"].(map[string]any)
+		if !ok {
+			return nil, fmt.Sprintf("entry[%d].request is required for transaction/batch", i)
+		}
+
+		method, _ := req["method"].(string)
+		url, _ := req["url"].(string)
+		if method == "" || url == "" {
+			return nil, fmt.Sprintf("entry[%d].request.method and request.url are required", i)
+		}
+
+		entry := store.BundleEntryRequest{
+			Method:      method,
+			URL:         url,
+			IfMatch:     stringField(req, "ifMatch"),
+			IfNoneExist: stringField(req, "ifNoneExist"),
+			FullURL:     stringField(entryMap, "fullUrl"),
+		}
+		if resource, ok := entryMap["resource"].(map[string]any); ok {
+			entry.Resource = resource
+		}
+		entries = append(entries, entry)
+	}
+	slog.Debug("parsed bundle entries", "count", len(entries))
+	return entries, ""
+}
+
+func stringField(m map[string]any, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}

--- a/miscellaneous/fhir-server-go/internal/handler/bundle_integration_test.go
+++ b/miscellaneous/fhir-server-go/internal/handler/bundle_integration_test.go
@@ -1,0 +1,245 @@
+//go:build integration
+
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// ─── Transaction: create with inter-entry reference resolution ─────────────────
+
+func TestIntegration_Transaction_CreateWithReferences(t *testing.T) {
+	srv := newRealServer(t)
+
+	bundle := map[string]any{
+		"resourceType": "Bundle",
+		"type":         "transaction",
+		"entry": []any{
+			map[string]any{
+				"fullUrl":  "urn:uuid:patient-1",
+				"resource": map[string]any{"resourceType": "Patient", "name": []any{map[string]any{"family": "Tx"}}},
+				"request":  map[string]any{"method": "POST", "url": "Patient"},
+			},
+			map[string]any{
+				"fullUrl": "urn:uuid:obs-1",
+				"resource": map[string]any{
+					"resourceType": "Observation",
+					"status":       "final",
+					"code":         map[string]any{"text": "hr"},
+					"subject":      map[string]any{"reference": "urn:uuid:patient-1"},
+				},
+				"request": map[string]any{"method": "POST", "url": "Observation"},
+			},
+		},
+	}
+
+	resp := iDo(t, srv, http.MethodPost, "/fhir/r4", bundle)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("transaction: want 200, got %d", resp.StatusCode)
+	}
+	body := iJSON(t, resp)
+	if body["type"] != "transaction-response" {
+		t.Fatalf("want transaction-response, got %v", body["type"])
+	}
+	entries := body["entry"].([]any)
+	if len(entries) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(entries))
+	}
+
+	// Both entries created.
+	for i, e := range entries {
+		resp := e.(map[string]any)["response"].(map[string]any)
+		if resp["status"] != "201 Created" {
+			t.Errorf("entry[%d] status = %v, want 201 Created", i, resp["status"])
+		}
+	}
+
+	// The Observation's subject reference must have been rewritten to Patient/<id>.
+	patientLoc := entries[0].(map[string]any)["response"].(map[string]any)["location"].(string)
+	patientID := lastPathID(patientLoc)
+	obs := entries[1].(map[string]any)["resource"].(map[string]any)
+	gotRef := obs["subject"].(map[string]any)["reference"].(string)
+	wantRef := "Patient/" + patientID
+	if gotRef != wantRef {
+		t.Errorf("subject.reference = %q, want %q", gotRef, wantRef)
+	}
+
+	// The Patient is actually retrievable.
+	rd := iDo(t, srv, http.MethodGet, "/fhir/r4/Patient/"+patientID, nil)
+	if rd.StatusCode != http.StatusOK {
+		t.Fatalf("read created Patient: want 200, got %d", rd.StatusCode)
+	}
+	rd.Body.Close()
+}
+
+// ─── Transaction: atomic rollback ──────────────────────────────────────────────
+
+func TestIntegration_Transaction_RollsBackOnError(t *testing.T) {
+	srv := newRealServer(t)
+
+	bundle := map[string]any{
+		"resourceType": "Bundle",
+		"type":         "transaction",
+		"entry": []any{
+			map[string]any{
+				"fullUrl":  "urn:uuid:good",
+				"resource": map[string]any{"resourceType": "Patient", "name": []any{map[string]any{"family": "ShouldNotPersist"}}},
+				"request":  map[string]any{"method": "POST", "url": "Patient"},
+			},
+			// This entry fails: PUT to a non-existent id WITH an If-Match guard,
+			// which cannot create and must error → whole transaction rolls back.
+			map[string]any{
+				"resource": map[string]any{"resourceType": "Patient", "id": "definitely-missing"},
+				"request": map[string]any{
+					"method":  "PUT",
+					"url":     "Patient/definitely-missing",
+					"ifMatch": "W/\"9\"",
+				},
+			},
+		},
+	}
+
+	resp := iDo(t, srv, http.MethodPost, "/fhir/r4", bundle)
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("expected transaction to fail, got 200")
+	}
+	body := iJSON(t, resp)
+	if body["resourceType"] != "OperationOutcome" {
+		t.Fatalf("want OperationOutcome on failure, got %v", body["resourceType"])
+	}
+
+	// The good Patient must NOT have been persisted (full rollback).
+	search := iDo(t, srv, http.MethodGet, "/fhir/r4/Patient?family=ShouldNotPersist", nil)
+	sbody := iJSON(t, search)
+	if total, _ := sbody["total"].(float64); total != 0 {
+		t.Errorf("rollback failed: found %v Patients that should not exist", total)
+	}
+}
+
+// ─── Batch: independent entries ────────────────────────────────────────────────
+
+func TestIntegration_Batch_IndependentEntries(t *testing.T) {
+	srv := newRealServer(t)
+
+	bundle := map[string]any{
+		"resourceType": "Bundle",
+		"type":         "batch",
+		"entry": []any{
+			map[string]any{
+				"resource": map[string]any{"resourceType": "Patient", "name": []any{map[string]any{"family": "BatchGood"}}},
+				"request":  map[string]any{"method": "POST", "url": "Patient"},
+			},
+			// Fails (404) but must not affect the good entry.
+			map[string]any{
+				"request": map[string]any{"method": "GET", "url": "Patient/does-not-exist"},
+			},
+		},
+	}
+
+	resp := iDo(t, srv, http.MethodPost, "/fhir/r4", bundle)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("batch: want 200 overall, got %d", resp.StatusCode)
+	}
+	body := iJSON(t, resp)
+	if body["type"] != "batch-response" {
+		t.Fatalf("want batch-response, got %v", body["type"])
+	}
+	entries := body["entry"].([]any)
+	if len(entries) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(entries))
+	}
+
+	r0 := entries[0].(map[string]any)["response"].(map[string]any)
+	if r0["status"] != "201 Created" {
+		t.Errorf("entry[0] status = %v, want 201 Created", r0["status"])
+	}
+	r1 := entries[1].(map[string]any)["response"].(map[string]any)
+	if status, _ := r1["status"].(string); status[:3] != "404" {
+		t.Errorf("entry[1] status = %v, want 404", r1["status"])
+	}
+
+	// The good Patient persisted despite the sibling failure.
+	search := iDo(t, srv, http.MethodGet, "/fhir/r4/Patient?family=BatchGood", nil)
+	sbody := iJSON(t, search)
+	if total, _ := sbody["total"].(float64); total != 1 {
+		t.Errorf("want 1 BatchGood Patient, got %v", total)
+	}
+}
+
+// ─── Transaction: conditional create (If-None-Exist) ───────────────────────────
+
+func TestIntegration_Transaction_ConditionalCreate(t *testing.T) {
+	srv := newRealServer(t)
+
+	// Seed a Patient with a unique identifier.
+	id, _ := iCreate(t, srv, "Patient", map[string]any{
+		"resourceType": "Patient",
+		"identifier":   []any{map[string]any{"system": "urn:cond", "value": "abc"}},
+	})
+
+	bundle := map[string]any{
+		"resourceType": "Bundle",
+		"type":         "transaction",
+		"entry": []any{
+			map[string]any{
+				"resource": map[string]any{
+					"resourceType": "Patient",
+					"identifier":   []any{map[string]any{"system": "urn:cond", "value": "abc"}},
+				},
+				"request": map[string]any{
+					"method":      "POST",
+					"url":         "Patient",
+					"ifNoneExist": "identifier=urn:cond|abc",
+				},
+			},
+		},
+	}
+
+	resp := iDo(t, srv, http.MethodPost, "/fhir/r4", bundle)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("conditional create: want 200, got %d", resp.StatusCode)
+	}
+	body := iJSON(t, resp)
+	entry := body["entry"].([]any)[0].(map[string]any)["response"].(map[string]any)
+	// Matched the existing one → 200, not a new create, pointing at the seeded id.
+	if entry["status"] != "200 OK" {
+		t.Errorf("status = %v, want 200 OK (matched existing)", entry["status"])
+	}
+	if loc, _ := entry["location"].(string); lastPathID(loc) != id {
+		t.Errorf("conditional create should reuse existing id %s, got location %v", id, loc)
+	}
+}
+
+// lastPathID returns the id segment of a location like ".../Patient/<id>/_history/1".
+func lastPathID(loc string) string {
+	parts := splitNonEmpty(loc, '/')
+	for i, p := range parts {
+		if p == "_history" && i > 0 {
+			return parts[i-1]
+		}
+	}
+	if len(parts) > 0 {
+		return parts[len(parts)-1]
+	}
+	return ""
+}
+
+func splitNonEmpty(s string, sep byte) []string {
+	var out []string
+	cur := ""
+	for i := 0; i < len(s); i++ {
+		if s[i] == sep {
+			if cur != "" {
+				out = append(out, cur)
+			}
+			cur = ""
+		} else {
+			cur += string(s[i])
+		}
+	}
+	if cur != "" {
+		out = append(out, cur)
+	}
+	return out
+}

--- a/miscellaneous/fhir-server-go/internal/handler/bundle_integration_test.go
+++ b/miscellaneous/fhir-server-go/internal/handler/bundle_integration_test.go
@@ -4,7 +4,15 @@ package handler_test
 
 import (
 	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
+
+	"github.com/wso2/open-healthcare-fhir-server-go/internal/handler"
+	"github.com/wso2/open-healthcare-fhir-server-go/internal/searchparam"
+	"github.com/wso2/open-healthcare-fhir-server-go/internal/store"
+	"github.com/wso2/open-healthcare-fhir-server-go/internal/testutil"
 )
 
 // ─── Transaction: create with inter-entry reference resolution ─────────────────
@@ -155,7 +163,7 @@ func TestIntegration_Batch_IndependentEntries(t *testing.T) {
 		t.Errorf("entry[0] status = %v, want 201 Created", r0["status"])
 	}
 	r1 := entries[1].(map[string]any)["response"].(map[string]any)
-	if status, _ := r1["status"].(string); status[:3] != "404" {
+	if status, _ := r1["status"].(string); !strings.HasPrefix(status, "404") {
 		t.Errorf("entry[1] status = %v, want 404", r1["status"])
 	}
 
@@ -208,6 +216,57 @@ func TestIntegration_Transaction_ConditionalCreate(t *testing.T) {
 	}
 	if loc, _ := entry["location"].(string); lastPathID(loc) != id {
 		t.Errorf("conditional create should reuse existing id %s, got location %v", id, loc)
+	}
+}
+
+// ─── Transaction: SearchParameter DELETE cleans up the registry ────────────────
+
+// newServerWithRegistry builds a real server but also returns the registry so a
+// test can assert custom SearchParameter definitions are added/removed.
+func newServerWithRegistry(t *testing.T) (*httptest.Server, *searchparam.Registry) {
+	t.Helper()
+	pool := testutil.MustSeededDB(t)
+	reg := testutil.MustRegistry(t, pool)
+	s := store.New(pool, reg)
+	var ready atomic.Int32
+	ready.Store(1)
+	srv := httptest.NewServer(handler.NewRouter(s, pool, reg, "http://test-server/fhir/r4", &ready))
+	t.Cleanup(srv.Close)
+	return srv, reg
+}
+
+func TestIntegration_Transaction_SearchParameterDeleteCleansUpRegistry(t *testing.T) {
+	srv, reg := newServerWithRegistry(t)
+
+	// Create a custom SearchParameter directly so it lands in the registry.
+	id, _ := iCreate(t, srv, "SearchParameter", map[string]any{
+		"resourceType": "SearchParameter",
+		"code":         "bundle-custom",
+		"base":         []any{"Patient"},
+		"type":         "string",
+		"expression":   "Patient.extension('http://example.com/bundle-custom')",
+	})
+	if _, ok := reg.Lookup("Patient", "bundle-custom"); !ok {
+		t.Fatal("custom SearchParameter should be in the registry after create")
+	}
+
+	// Delete it via a transaction Bundle. Before the fix, the Bundle path never
+	// called DeleteSearchParameter, so the registry/definition leaked.
+	bundle := map[string]any{
+		"resourceType": "Bundle",
+		"type":         "transaction",
+		"entry": []any{map[string]any{
+			"request": map[string]any{"method": "DELETE", "url": "SearchParameter/" + id},
+		}},
+	}
+	resp := iDo(t, srv, http.MethodPost, "/fhir/r4", bundle)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("transaction delete: want 200, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	if _, ok := reg.Lookup("Patient", "bundle-custom"); ok {
+		t.Error("custom SearchParameter should be removed from the registry after Bundle DELETE")
 	}
 }
 

--- a/miscellaneous/fhir-server-go/internal/handler/bundle_test.go
+++ b/miscellaneous/fhir-server-go/internal/handler/bundle_test.go
@@ -1,0 +1,116 @@
+package handler_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/wso2/open-healthcare-fhir-server-go/internal/store"
+)
+
+func TestBundle_RoutesAndShapesTransactionResponse(t *testing.T) {
+	ms := &mockStore{
+		executeBundleFn: func(_ context.Context, bundleType, baseURL string, entries []store.BundleEntryRequest) ([]store.BundleEntryResult, error) {
+			if bundleType != "transaction" {
+				t.Errorf("bundleType = %q, want transaction", bundleType)
+			}
+			if len(entries) != 1 || entries[0].Method != "POST" {
+				t.Errorf("entries not parsed: %+v", entries)
+			}
+			return []store.BundleEntryResult{{
+				Status:   "201 Created",
+				Location: "Patient/123/_history/1",
+				ETag:     `W/"1"`,
+				Resource: map[string]any{"resourceType": "Patient", "id": "123"},
+			}}, nil
+		},
+	}
+	h := newRouter(ms)
+
+	resp := do(t, h, http.MethodPost, "/fhir/r4", map[string]any{
+		"resourceType": "Bundle",
+		"type":         "transaction",
+		"entry": []any{map[string]any{
+			"resource": map[string]any{"resourceType": "Patient"},
+			"request":  map[string]any{"method": "POST", "url": "Patient"},
+		}},
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", resp.Code, resp.Body.String())
+	}
+	body := decodeJSON(t, resp)
+	if body["type"] != "transaction-response" {
+		t.Errorf("type = %v, want transaction-response", body["type"])
+	}
+	entries, _ := body["entry"].([]any)
+	if len(entries) != 1 {
+		t.Fatalf("want 1 response entry, got %d", len(entries))
+	}
+	respObj := entries[0].(map[string]any)["response"].(map[string]any)
+	if respObj["status"] != "201 Created" {
+		t.Errorf("status = %v, want 201 Created", respObj["status"])
+	}
+	// Location must be made absolute under the server base.
+	if respObj["location"] != "http://localhost:9090/fhir/r4/Patient/123/_history/1" {
+		t.Errorf("location = %v, want absolute", respObj["location"])
+	}
+}
+
+func TestBundle_RejectsNonBundle(t *testing.T) {
+	h := newRouter(&mockStore{})
+	resp := do(t, h, http.MethodPost, "/fhir/r4", map[string]any{"resourceType": "Patient"})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.Code)
+	}
+}
+
+func TestBundle_RejectsBadType(t *testing.T) {
+	h := newRouter(&mockStore{})
+	resp := do(t, h, http.MethodPost, "/fhir/r4", map[string]any{
+		"resourceType": "Bundle",
+		"type":         "collection",
+	})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for non-transaction/batch type", resp.Code)
+	}
+}
+
+func TestBundle_TransactionErrorMapsStatus(t *testing.T) {
+	ms := &mockStore{
+		executeBundleFn: func(_ context.Context, _, _ string, _ []store.BundleEntryRequest) ([]store.BundleEntryResult, error) {
+			return nil, &store.BundleError{HTTPStatus: 404, Code: "not-found", EntryIndex: 0, Diagnostics: "Patient/x not found"}
+		},
+	}
+	h := newRouter(ms)
+	resp := do(t, h, http.MethodPost, "/fhir/r4", map[string]any{
+		"resourceType": "Bundle",
+		"type":         "transaction",
+		"entry": []any{map[string]any{
+			"request": map[string]any{"method": "DELETE", "url": "Patient/x"},
+		}},
+	})
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.Code)
+	}
+	body := decodeJSON(t, resp)
+	if body["resourceType"] != "OperationOutcome" {
+		t.Errorf("want OperationOutcome, got %v", body["resourceType"])
+	}
+}
+
+func TestBundle_TrailingSlashAlsoRoutes(t *testing.T) {
+	called := false
+	ms := &mockStore{
+		executeBundleFn: func(_ context.Context, _, _ string, _ []store.BundleEntryRequest) ([]store.BundleEntryResult, error) {
+			called = true
+			return []store.BundleEntryResult{}, nil
+		},
+	}
+	h := newRouter(ms)
+	resp := do(t, h, http.MethodPost, "/fhir/r4/", map[string]any{
+		"resourceType": "Bundle", "type": "batch",
+	})
+	if resp.Code != http.StatusOK || !called {
+		t.Fatalf("trailing-slash POST did not route to bundle handler: status=%d called=%v", resp.Code, called)
+	}
+}

--- a/miscellaneous/fhir-server-go/internal/handler/handler_test.go
+++ b/miscellaneous/fhir-server-go/internal/handler/handler_test.go
@@ -28,6 +28,7 @@ type mockStore struct {
 	fetchReferencesFn   func(ctx context.Context, rt, id string, reverse bool) ([]map[string]any, error)
 	syncSearchParamFn   func(ctx context.Context, body map[string]any) error
 	deleteSearchParamFn func(ctx context.Context, id string) error
+	executeBundleFn     func(ctx context.Context, bundleType, baseURL string, entries []store.BundleEntryRequest) ([]store.BundleEntryResult, error)
 }
 
 func (m *mockStore) Read(ctx context.Context, rt, id string) (map[string]any, error) {
@@ -74,6 +75,12 @@ func (m *mockStore) DeleteSearchParameter(ctx context.Context, id string) error 
 		return m.deleteSearchParamFn(ctx, id)
 	}
 	return nil
+}
+func (m *mockStore) ExecuteBundle(ctx context.Context, bundleType, baseURL string, entries []store.BundleEntryRequest) ([]store.BundleEntryResult, error) {
+	if m.executeBundleFn != nil {
+		return m.executeBundleFn(ctx, bundleType, baseURL, entries)
+	}
+	return nil, nil
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/miscellaneous/fhir-server-go/internal/handler/handlers.go
+++ b/miscellaneous/fhir-server-go/internal/handler/handlers.go
@@ -695,8 +695,12 @@ func (h *fhirHandler) metadata(w http.ResponseWriter, r *http.Request) {
 			"version": "1.0.0",
 		},
 		"rest": []any{map[string]any{
-			"mode":      "server",
-			"resource":  resources,
+			"mode":     "server",
+			"resource": resources,
+			"interaction": []any{
+				map[string]any{"code": "transaction"},
+				map[string]any{"code": "batch"},
+			},
 			"operation": []any{map[string]any{"name": "everything", "definition": "http://hl7.org/fhir/OperationDefinition/Patient-everything"}},
 		}},
 	}

--- a/miscellaneous/fhir-server-go/internal/handler/router.go
+++ b/miscellaneous/fhir-server-go/internal/handler/router.go
@@ -31,9 +31,17 @@ func NewRouter(s StoreAPI, pool *pgxpool.Pool, registry *searchparam.Registry, b
 		}
 	})
 
+	// System-level transaction / batch Bundle, posted to the FHIR base. Registered
+	// without a trailing slash here and with one below so both /fhir/r4 and
+	// /fhir/r4/ are accepted.
+	r.Post("/fhir/r4", h.bundle)
+
 	r.Route("/fhir/r4", func(r chi.Router) {
 		// Capability statement
 		r.Get("/metadata", h.metadata)
+
+		// System-level transaction / batch Bundle (trailing-slash form)
+		r.Post("/", h.bundle)
 
 		// Per-resource-type routes
 		r.Route("/{resourceType}", func(r chi.Router) {

--- a/miscellaneous/fhir-server-go/internal/handler/store.go
+++ b/miscellaneous/fhir-server-go/internal/handler/store.go
@@ -21,4 +21,5 @@ type StoreAPI interface {
 	FetchReferences(ctx context.Context, resourceType, resourceID string, reverse bool) ([]map[string]any, error)
 	SyncSearchParameter(ctx context.Context, body map[string]any) error
 	DeleteSearchParameter(ctx context.Context, resourceID string) error
+	ExecuteBundle(ctx context.Context, bundleType, baseURL string, entries []store.BundleEntryRequest) ([]store.BundleEntryResult, error)
 }

--- a/miscellaneous/fhir-server-go/internal/index/extractor.go
+++ b/miscellaneous/fhir-server-go/internal/index/extractor.go
@@ -158,6 +158,11 @@ func insertToken(ctx context.Context, tx pgx.Tx, rt, rid, param string, v any) e
 	sys := asString(m["system"])
 	code := asString(m["code"])
 	display := asString(m["display"])
+	// Identifier and ContactPoint carry their token in "value" rather than
+	// "code"; fall back to it so identifier/telecom token searches match.
+	if code == "" {
+		code = asString(m["value"])
+	}
 	if code == "" {
 		return nil
 	}

--- a/miscellaneous/fhir-server-go/internal/store/bundle.go
+++ b/miscellaneous/fhir-server-go/internal/store/bundle.go
@@ -33,6 +33,13 @@ type BundleEntryResult struct {
 	ETag     string         // entry.response.etag, e.g. W/"1"
 	Resource map[string]any // entry.resource for the response (POST/PUT/GET payloads)
 	Outcome  map[string]any // OperationOutcome — set for batch entries that failed
+
+	// Method/ResourceType/ID describe the interaction that produced this result.
+	// They let the handler run post-commit maintenance (e.g. SearchParameter
+	// registry sync/cleanup) uniformly, including for DELETE which has no Resource.
+	Method       string
+	ResourceType string
+	ID           string
 }
 
 // BundleError is returned by ExecuteBundle when a transaction (atomic) Bundle
@@ -154,9 +161,30 @@ func (s *Store) executeTransaction(ctx context.Context, baseURL string, entries 
 	return results, nil
 }
 
-// execOpInTx runs a single planned op against an open transaction. A returned
+// execOpInTx runs a single planned op against an open transaction, stamping the
+// result with the interaction's method/type/id so the caller can run post-commit
+// maintenance (e.g. SearchParameter registry sync) uniformly. A returned
 // *BundleError aborts (and rolls back) the whole transaction.
 func (s *Store) execOpInTx(ctx context.Context, tx pgx.Tx, op bundleOp) (BundleEntryResult, *BundleError) {
+	res, berr := s.runOpInTx(ctx, tx, op)
+	if berr != nil {
+		return res, berr
+	}
+	res.Method = op.method
+	if op.skip && op.skipResType != "" {
+		res.ResourceType = op.skipResType
+		res.ID = op.skipID
+	} else {
+		res.ResourceType = op.resourceType
+		if res.ID == "" {
+			res.ID = op.id
+		}
+	}
+	return res, nil
+}
+
+// runOpInTx executes a single planned op against the open transaction.
+func (s *Store) runOpInTx(ctx context.Context, tx pgx.Tx, op bundleOp) (BundleEntryResult, *BundleError) {
 	if op.skip {
 		return BundleEntryResult{
 			Status:   op.skipStatus,

--- a/miscellaneous/fhir-server-go/internal/store/bundle.go
+++ b/miscellaneous/fhir-server-go/internal/store/bundle.go
@@ -1,0 +1,646 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// ─── Bundle request / response types ──────────────────────────────────────────
+
+// BundleEntryRequest is one parsed entry of a transaction or batch Bundle.
+type BundleEntryRequest struct {
+	FullURL     string         // entry.fullUrl (e.g. "urn:uuid:…" or an absolute URL)
+	Resource    map[string]any // entry.resource (nil for GET/DELETE)
+	Method      string         // entry.request.method — GET, POST, PUT, PATCH, DELETE
+	URL         string         // entry.request.url — "Patient", "Patient/123", "Patient?name=x"
+	IfMatch     string         // entry.request.ifMatch — ETag, e.g. W/"2"
+	IfNoneExist string         // entry.request.ifNoneExist — conditional-create query
+}
+
+// BundleEntryResult is the outcome of processing one entry. It maps to a
+// transaction-response / batch-response Bundle entry.
+type BundleEntryResult struct {
+	Status   string         // HTTP status line, e.g. "201 Created"
+	Location string         // entry.response.location (relative, e.g. "Patient/123/_history/1")
+	ETag     string         // entry.response.etag, e.g. W/"1"
+	Resource map[string]any // entry.resource for the response (POST/PUT/GET payloads)
+	Outcome  map[string]any // OperationOutcome — set for batch entries that failed
+}
+
+// BundleError is returned by ExecuteBundle when a transaction (atomic) Bundle
+// fails. It carries the HTTP status the handler should surface and a diagnostic
+// message; the whole transaction has already been rolled back.
+type BundleError struct {
+	HTTPStatus  int
+	Code        string // FHIR issue code, e.g. "processing", "not-found"
+	EntryIndex  int    // 0-based index of the offending entry, or -1
+	Diagnostics string
+}
+
+func (e *BundleError) Error() string {
+	if e.EntryIndex >= 0 {
+		return fmt.Sprintf("bundle entry %d: %s", e.EntryIndex, e.Diagnostics)
+	}
+	return e.Diagnostics
+}
+
+// bundleOp is the planned, reference-resolved form of a BundleEntryRequest,
+// ready for ordered execution.
+type bundleOp struct {
+	origIndex    int
+	method       string
+	resourceType string
+	id           string // resolved target id (PUT/PATCH/DELETE/GET-read)
+	versionID    string // for GET vread (_history/{vid})
+	body         map[string]any
+	ifMatch      int        // parsed If-Match version, or -1 for none
+	query        url.Values // GET search / conditional delete filter
+	isSearch     bool       // GET against a type (search) vs GET of an instance (read)
+	allowCreate  bool       // PUT may create when the target is missing (conditional update, 0 matches)
+
+	// conditional-create / -update that matched an existing resource: no write
+	// is performed and the entry resolves to the matched resource.
+	skip        bool
+	skipStatus  string
+	skipResType string
+	skipID      string
+}
+
+// ─── Entry point ──────────────────────────────────────────────────────────────
+
+// ExecuteBundle processes a transaction or batch Bundle.
+//
+//   - "transaction": all entries are applied atomically in a single DB
+//     transaction. urn:uuid references between entries are resolved, entries are
+//     processed in FHIR verb order (DELETE, POST, PUT/PATCH, GET), and any error
+//     rolls the whole Bundle back and returns a *BundleError.
+//   - "batch": each entry is applied independently in its own transaction; a
+//     failing entry yields an OperationOutcome in its response and does not
+//     affect the others. ExecuteBundle itself returns a nil error.
+//
+// baseURL is used to recognise references written as absolute URLs.
+func (s *Store) ExecuteBundle(ctx context.Context, bundleType, baseURL string, entries []BundleEntryRequest) ([]BundleEntryResult, error) {
+	switch bundleType {
+	case "transaction":
+		return s.executeTransaction(ctx, baseURL, entries)
+	case "batch":
+		return s.executeBatch(ctx, baseURL, entries), nil
+	default:
+		return nil, &BundleError{
+			HTTPStatus:  400,
+			Code:        "value",
+			EntryIndex:  -1,
+			Diagnostics: fmt.Sprintf("Bundle.type must be 'transaction' or 'batch', got %q", bundleType),
+		}
+	}
+}
+
+// ─── Transaction (atomic) ──────────────────────────────────────────────────────
+
+func (s *Store) executeTransaction(ctx context.Context, baseURL string, entries []BundleEntryRequest) ([]BundleEntryResult, error) {
+	// Plan: assign ids, resolve conditionals, build the reference map.
+	ops, refMap, err := s.planOps(ctx, baseURL, entries)
+	if err != nil {
+		return nil, err
+	}
+
+	// Rewrite urn:uuid / absolute-URL references to "Type/id" form across every
+	// resource body so inter-entry references point at the assigned ids.
+	for i := range ops {
+		if ops[i].body != nil {
+			rewriteReferences(ops[i].body, refMap)
+		}
+	}
+
+	// Process in FHIR verb order, preserving original order within each verb.
+	order := make([]int, len(ops))
+	for i := range order {
+		order[i] = i
+	}
+	sort.SliceStable(order, func(a, b int) bool {
+		return methodOrder(ops[order[a]].method) < methodOrder(ops[order[b]].method)
+	})
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, &BundleError{HTTPStatus: 500, Code: "exception", EntryIndex: -1, Diagnostics: err.Error()}
+	}
+	defer tx.Rollback(ctx)
+
+	results := make([]BundleEntryResult, len(ops))
+	for _, idx := range order {
+		op := ops[idx]
+		res, berr := s.execOpInTx(ctx, tx, op)
+		if berr != nil {
+			berr.EntryIndex = op.origIndex
+			return nil, berr // defer rolls the whole transaction back
+		}
+		results[op.origIndex] = res
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, &BundleError{HTTPStatus: 500, Code: "exception", EntryIndex: -1, Diagnostics: err.Error()}
+	}
+
+	slog.Info("processed transaction bundle", "entries", len(entries))
+	return results, nil
+}
+
+// execOpInTx runs a single planned op against an open transaction. A returned
+// *BundleError aborts (and rolls back) the whole transaction.
+func (s *Store) execOpInTx(ctx context.Context, tx pgx.Tx, op bundleOp) (BundleEntryResult, *BundleError) {
+	if op.skip {
+		return BundleEntryResult{
+			Status:   op.skipStatus,
+			Location: op.skipResType + "/" + op.skipID,
+		}, nil
+	}
+
+	switch op.method {
+	case "POST":
+		res, err := s.createInTx(ctx, tx, op.resourceType, op.body)
+		if err != nil {
+			return BundleEntryResult{}, storeErrToBundleErr(err)
+		}
+		id, _ := res["id"].(string)
+		return BundleEntryResult{
+			Status:   "201 Created",
+			Location: fmt.Sprintf("%s/%s/_history/%s", op.resourceType, id, metaVersionID(res)),
+			ETag:     etag(res),
+			Resource: res,
+		}, nil
+
+	case "PUT":
+		res, err := s.updateInTx(ctx, tx, op.resourceType, op.id, op.body, op.ifMatch)
+		if err != nil {
+			// A conditional update that matched zero resources creates the target;
+			// a plain PUT to a missing id is a 404 (the server does not do
+			// update-as-create), which in a transaction rolls everything back.
+			if _, ok := err.(NotFoundError); ok && op.allowCreate {
+				op.body["id"] = op.id
+				cres, cerr := s.createInTx(ctx, tx, op.resourceType, op.body)
+				if cerr != nil {
+					return BundleEntryResult{}, storeErrToBundleErr(cerr)
+				}
+				cid, _ := cres["id"].(string)
+				return BundleEntryResult{
+					Status:   "201 Created",
+					Location: fmt.Sprintf("%s/%s/_history/%s", op.resourceType, cid, metaVersionID(cres)),
+					ETag:     etag(cres),
+					Resource: cres,
+				}, nil
+			}
+			return BundleEntryResult{}, storeErrToBundleErr(err)
+		}
+		id, _ := res["id"].(string)
+		return BundleEntryResult{
+			Status:   "200 OK",
+			Location: fmt.Sprintf("%s/%s/_history/%s", op.resourceType, id, metaVersionID(res)),
+			ETag:     etag(res),
+			Resource: res,
+		}, nil
+
+	case "PATCH":
+		res, _, err := s.patchInTx(ctx, tx, op.resourceType, op.id, op.body)
+		if err != nil {
+			return BundleEntryResult{}, storeErrToBundleErr(err)
+		}
+		id, _ := res["id"].(string)
+		return BundleEntryResult{
+			Status:   "200 OK",
+			Location: fmt.Sprintf("%s/%s/_history/%s", op.resourceType, id, metaVersionID(res)),
+			ETag:     etag(res),
+			Resource: res,
+		}, nil
+
+	case "DELETE":
+		if err := s.deleteInTx(ctx, tx, op.resourceType, op.id); err != nil {
+			if _, ok := err.(NotFoundError); ok {
+				// Deleting something that does not exist is a no-op success.
+				return BundleEntryResult{Status: "204 No Content"}, nil
+			}
+			return BundleEntryResult{}, storeErrToBundleErr(err)
+		}
+		return BundleEntryResult{Status: "204 No Content"}, nil
+
+	case "GET":
+		return s.execGetInTx(ctx, tx, op)
+
+	default:
+		return BundleEntryResult{}, &BundleError{
+			HTTPStatus: 405, Code: "not-supported",
+			Diagnostics: fmt.Sprintf("unsupported Bundle request method %q", op.method),
+		}
+	}
+}
+
+func (s *Store) execGetInTx(ctx context.Context, tx pgx.Tx, op bundleOp) (BundleEntryResult, *BundleError) {
+	// Instance read (optionally a specific version) is served from the open
+	// transaction so it reflects earlier entries in the same Bundle.
+	if !op.isSearch {
+		if op.versionID != "" {
+			vid, _ := strconv.Atoi(op.versionID)
+			res, err := s.GetVersion(ctx, op.resourceType, op.id, vid)
+			if err != nil {
+				return BundleEntryResult{}, storeErrToBundleErr(err)
+			}
+			return BundleEntryResult{Status: "200 OK", Resource: res, ETag: etag(res)}, nil
+		}
+		res, err := s.readInTx(ctx, tx, op.resourceType, op.id)
+		if err != nil {
+			return BundleEntryResult{}, storeErrToBundleErr(err)
+		}
+		return BundleEntryResult{Status: "200 OK", Resource: res, ETag: etag(res)}, nil
+	}
+
+	// Search is served from the committed snapshot (the pool), so it does not
+	// observe not-yet-committed writes from earlier entries in this Bundle.
+	result, err := s.Search(ctx, SearchParams{ResourceType: op.resourceType, Params: valuesToMap(op.query)})
+	if err != nil {
+		return BundleEntryResult{}, &BundleError{HTTPStatus: 500, Code: "exception", Diagnostics: err.Error()}
+	}
+	return BundleEntryResult{Status: "200 OK", Resource: searchsetBundle(result)}, nil
+}
+
+// ─── Batch (independent entries) ───────────────────────────────────────────────
+
+func (s *Store) executeBatch(ctx context.Context, baseURL string, entries []BundleEntryRequest) []BundleEntryResult {
+	results := make([]BundleEntryResult, len(entries))
+	for i, e := range entries {
+		ops, _, err := s.planOps(ctx, baseURL, []BundleEntryRequest{e})
+		if err != nil {
+			results[i] = batchFailure(err)
+			continue
+		}
+		op := ops[0]
+		op.origIndex = 0
+
+		tx, txerr := s.pool.Begin(ctx)
+		if txerr != nil {
+			results[i] = batchFailure(&BundleError{HTTPStatus: 500, Code: "exception", Diagnostics: txerr.Error()})
+			continue
+		}
+		res, berr := s.execOpInTx(ctx, tx, op)
+		if berr != nil {
+			tx.Rollback(ctx)
+			results[i] = batchFailure(berr)
+			continue
+		}
+		if cerr := tx.Commit(ctx); cerr != nil {
+			results[i] = batchFailure(&BundleError{HTTPStatus: 500, Code: "exception", Diagnostics: cerr.Error()})
+			continue
+		}
+		results[i] = res
+	}
+	slog.Info("processed batch bundle", "entries", len(entries))
+	return results
+}
+
+func batchFailure(err error) BundleEntryResult {
+	be, ok := err.(*BundleError)
+	if !ok {
+		be = &BundleError{HTTPStatus: 500, Code: "exception", Diagnostics: err.Error()}
+	}
+	return BundleEntryResult{
+		Status:  fmt.Sprintf("%d %s", be.HTTPStatus, httpReason(be.HTTPStatus)),
+		Outcome: operationOutcomeMap("error", be.Code, be.Diagnostics),
+	}
+}
+
+// ─── Planning: id assignment, conditional resolution, reference map ────────────
+
+func (s *Store) planOps(ctx context.Context, baseURL string, entries []BundleEntryRequest) ([]bundleOp, map[string]string, error) {
+	ops := make([]bundleOp, len(entries))
+	refMap := map[string]string{}
+
+	for i, e := range entries {
+		method := strings.ToUpper(strings.TrimSpace(e.Method))
+		if method == "" {
+			return nil, nil, &BundleError{HTTPStatus: 400, Code: "required", EntryIndex: i, Diagnostics: "entry.request.method is required"}
+		}
+		rt, id, vid, query, perr := parseEntryURL(baseURL, e.URL)
+		if perr != "" {
+			return nil, nil, &BundleError{HTTPStatus: 400, Code: "value", EntryIndex: i, Diagnostics: perr}
+		}
+
+		op := bundleOp{origIndex: i, method: method, resourceType: rt, id: id, versionID: vid, body: e.Resource, ifMatch: -1}
+
+		if e.IfMatch != "" {
+			if v, ok := parseETagVersion(e.IfMatch); ok {
+				op.ifMatch = v
+			} else {
+				return nil, nil, &BundleError{HTTPStatus: 400, Code: "value", EntryIndex: i, Diagnostics: "invalid If-Match in entry.request.ifMatch"}
+			}
+		}
+
+		switch method {
+		case "POST":
+			if rt == "" {
+				return nil, nil, &BundleError{HTTPStatus: 400, Code: "value", EntryIndex: i, Diagnostics: "POST entry.request.url must be a resource type"}
+			}
+			// Conditional create (If-None-Exist): reuse an existing match if present.
+			if e.IfNoneExist != "" {
+				existingID, count, serr := s.conditionalMatch(ctx, rt, e.IfNoneExist)
+				if serr != nil {
+					return nil, nil, &BundleError{HTTPStatus: 500, Code: "exception", EntryIndex: i, Diagnostics: serr.Error()}
+				}
+				if count > 1 {
+					return nil, nil, &BundleError{HTTPStatus: 412, Code: "conflict", EntryIndex: i, Diagnostics: fmt.Sprintf("If-None-Exist matched %d resources", count)}
+				}
+				if count == 1 {
+					op.skip = true
+					op.skipStatus = "200 OK"
+					op.skipResType = rt
+					op.skipID = existingID
+					if e.FullURL != "" {
+						refMap[e.FullURL] = rt + "/" + existingID
+					}
+					ops[i] = op
+					continue
+				}
+			}
+			// Assign an id up front so other entries can reference this one.
+			newID := assignedID(e.Resource)
+			op.id = newID
+			if op.body == nil {
+				op.body = map[string]any{}
+			}
+			op.body["id"] = newID
+			op.body["resourceType"] = rt
+			if e.FullURL != "" {
+				refMap[e.FullURL] = rt + "/" + newID
+			}
+
+		case "PUT":
+			if rt == "" {
+				return nil, nil, &BundleError{HTTPStatus: 400, Code: "value", EntryIndex: i, Diagnostics: "PUT entry.request.url must include a resource type"}
+			}
+			// Conditional update: url carries a query and no id.
+			if id == "" && len(query) > 0 {
+				existingID, count, serr := s.conditionalMatch(ctx, rt, query.Encode())
+				if serr != nil {
+					return nil, nil, &BundleError{HTTPStatus: 500, Code: "exception", EntryIndex: i, Diagnostics: serr.Error()}
+				}
+				if count > 1 {
+					return nil, nil, &BundleError{HTTPStatus: 412, Code: "conflict", EntryIndex: i, Diagnostics: fmt.Sprintf("conditional update matched %d resources", count)}
+				}
+				if count == 1 {
+					op.id = existingID
+				} else {
+					op.id = assignedID(e.Resource) // create with a fresh (or body-supplied) id
+					op.allowCreate = true
+				}
+			}
+			if op.id == "" {
+				return nil, nil, &BundleError{HTTPStatus: 400, Code: "value", EntryIndex: i, Diagnostics: "PUT entry.request.url must include an id or a conditional query"}
+			}
+			if e.FullURL != "" {
+				refMap[e.FullURL] = rt + "/" + op.id
+			}
+
+		case "PATCH", "DELETE":
+			// Conditional delete: url carries a query and no id.
+			if id == "" && len(query) > 0 {
+				existingID, count, serr := s.conditionalMatch(ctx, rt, query.Encode())
+				if serr != nil {
+					return nil, nil, &BundleError{HTTPStatus: 500, Code: "exception", EntryIndex: i, Diagnostics: serr.Error()}
+				}
+				if count == 0 {
+					op.skip = true
+					op.skipStatus = "204 No Content"
+					ops[i] = op
+					continue
+				}
+				if count > 1 {
+					return nil, nil, &BundleError{HTTPStatus: 412, Code: "conflict", EntryIndex: i, Diagnostics: fmt.Sprintf("conditional %s matched %d resources", method, count)}
+				}
+				op.id = existingID
+			}
+			if op.id == "" {
+				return nil, nil, &BundleError{HTTPStatus: 400, Code: "value", EntryIndex: i, Diagnostics: method + " entry.request.url must include an id or a conditional query"}
+			}
+
+		case "GET":
+			if rt == "" {
+				return nil, nil, &BundleError{HTTPStatus: 400, Code: "value", EntryIndex: i, Diagnostics: "GET entry.request.url must include a resource type"}
+			}
+			op.isSearch = id == ""
+			op.query = query
+		}
+
+		ops[i] = op
+	}
+
+	return ops, refMap, nil
+}
+
+// conditionalMatch runs a search and returns the single matched id (if count==1),
+// the total match count, and any error.
+func (s *Store) conditionalMatch(ctx context.Context, resourceType, rawQuery string) (id string, count int, err error) {
+	q, perr := url.ParseQuery(rawQuery)
+	if perr != nil {
+		return "", 0, perr
+	}
+	result, serr := s.Search(ctx, SearchParams{ResourceType: resourceType, Params: valuesToMap(q), PageSize: 2})
+	if serr != nil {
+		return "", 0, serr
+	}
+	if result.Total == 1 && len(result.Entries) == 1 {
+		id, _ = result.Entries[0]["id"].(string)
+	}
+	return id, result.Total, nil
+}
+
+// ─── URL / reference helpers ───────────────────────────────────────────────────
+
+// parseEntryURL splits a Bundle entry.request.url (relative to the FHIR base,
+// or absolute under baseURL) into its parts. On a malformed URL it returns a
+// non-empty error string.
+func parseEntryURL(baseURL, raw string) (resourceType, id, versionID string, query url.Values, errMsg string) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", "", "", nil, "entry.request.url is required"
+	}
+	// Strip an absolute base if present.
+	if baseURL != "" && strings.HasPrefix(raw, baseURL) {
+		raw = strings.TrimPrefix(raw, baseURL)
+	} else if i := strings.Index(raw, "://"); i >= 0 {
+		if slash := strings.IndexByte(raw[i+3:], '/'); slash >= 0 {
+			raw = raw[i+3+slash:]
+		}
+	}
+	raw = strings.TrimPrefix(raw, "/")
+
+	path := raw
+	if q := strings.IndexByte(raw, '?'); q >= 0 {
+		path = raw[:q]
+		parsed, err := url.ParseQuery(raw[q+1:])
+		if err != nil {
+			return "", "", "", nil, "invalid query string in entry.request.url"
+		}
+		query = parsed
+	}
+
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	switch {
+	case len(parts) >= 4 && parts[2] == "_history":
+		// Type/id/_history/vid
+		return parts[0], parts[1], parts[3], query, ""
+	case len(parts) == 2:
+		return parts[0], parts[1], "", query, ""
+	case len(parts) == 1:
+		return parts[0], "", "", query, ""
+	default:
+		return "", "", "", nil, fmt.Sprintf("unsupported entry.request.url %q", raw)
+	}
+}
+
+// assignedID returns the resource's own id if present, otherwise a new uuid.
+func assignedID(body map[string]any) string {
+	if body != nil {
+		if id, ok := body["id"].(string); ok && id != "" {
+			return id
+		}
+	}
+	return uuid.NewString()
+}
+
+// rewriteReferences walks a resource and rewrites any {"reference": "<key>"}
+// whose value matches a key in refMap (a urn:uuid or absolute URL) to the
+// resolved "Type/id" form. It recurses through nested objects and arrays.
+func rewriteReferences(node any, refMap map[string]string) {
+	switch v := node.(type) {
+	case map[string]any:
+		if ref, ok := v["reference"].(string); ok {
+			if resolved, found := refMap[ref]; found {
+				v["reference"] = resolved
+			}
+		}
+		for _, child := range v {
+			rewriteReferences(child, refMap)
+		}
+	case []any:
+		for _, child := range v {
+			rewriteReferences(child, refMap)
+		}
+	}
+}
+
+// methodOrder gives the FHIR transaction processing order for a verb.
+func methodOrder(method string) int {
+	switch method {
+	case "DELETE":
+		return 0
+	case "POST":
+		return 1
+	case "PUT":
+		return 2
+	case "PATCH":
+		return 3
+	default: // GET, HEAD
+		return 4
+	}
+}
+
+// ─── Small shared helpers ──────────────────────────────────────────────────────
+
+func valuesToMap(v url.Values) map[string][]string {
+	m := make(map[string][]string, len(v))
+	for k, vs := range v {
+		m[k] = vs
+	}
+	return m
+}
+
+func etag(res map[string]any) string {
+	if v := metaVersionID(res); v != "" {
+		return fmt.Sprintf(`W/"%s"`, v)
+	}
+	return ""
+}
+
+// parseETagVersion parses an ETag like W/"3" into its integer version.
+func parseETagVersion(header string) (int, bool) {
+	s := strings.TrimSpace(header)
+	s = strings.TrimPrefix(s, "W/")
+	s = strings.Trim(s, `"`)
+	v, err := strconv.Atoi(s)
+	return v, err == nil
+}
+
+func operationOutcomeMap(severity, code, diagnostics string) map[string]any {
+	return map[string]any{
+		"resourceType": "OperationOutcome",
+		"issue": []any{map[string]any{
+			"severity":    severity,
+			"code":        code,
+			"diagnostics": diagnostics,
+		}},
+	}
+}
+
+// searchsetBundle wraps search results in a minimal searchset Bundle for use as
+// a GET response inside a transaction/batch response.
+func searchsetBundle(result SearchResult) map[string]any {
+	entries := make([]any, 0, len(result.Entries))
+	for _, res := range result.Entries {
+		entries = append(entries, map[string]any{
+			"resource": res,
+			"search":   map[string]any{"mode": "match"},
+		})
+	}
+	return map[string]any{
+		"resourceType": "Bundle",
+		"type":         "searchset",
+		"total":        result.Total,
+		"entry":        entries,
+	}
+}
+
+// storeErrToBundleErr maps a store CRUD error to the HTTP status a Bundle entry
+// (or a failed transaction) should report.
+func storeErrToBundleErr(err error) *BundleError {
+	switch e := err.(type) {
+	case NotFoundError:
+		return &BundleError{HTTPStatus: 404, Code: "not-found", Diagnostics: e.Error()}
+	case GoneError:
+		return &BundleError{HTTPStatus: 410, Code: "deleted", Diagnostics: e.Error()}
+	case ConflictError:
+		return &BundleError{HTTPStatus: 412, Code: "conflict", Diagnostics: e.Error()}
+	default:
+		return &BundleError{HTTPStatus: 500, Code: "exception", Diagnostics: err.Error()}
+	}
+}
+
+func httpReason(status int) string {
+	switch status {
+	case 200:
+		return "OK"
+	case 201:
+		return "Created"
+	case 204:
+		return "No Content"
+	case 400:
+		return "Bad Request"
+	case 404:
+		return "Not Found"
+	case 405:
+		return "Method Not Allowed"
+	case 410:
+		return "Gone"
+	case 412:
+		return "Precondition Failed"
+	case 422:
+		return "Unprocessable Entity"
+	default:
+		return "Internal Server Error"
+	}
+}

--- a/miscellaneous/fhir-server-go/internal/store/bundle_test.go
+++ b/miscellaneous/fhir-server-go/internal/store/bundle_test.go
@@ -1,0 +1,123 @@
+package store
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseEntryURL(t *testing.T) {
+	const base = "http://test-server/fhir/r4"
+	cases := []struct {
+		name    string
+		raw     string
+		wantRT  string
+		wantID  string
+		wantVer string
+		wantErr bool
+	}{
+		{"type only", "Patient", "Patient", "", "", false},
+		{"type and id", "Patient/123", "Patient", "123", "", false},
+		{"search query", "Patient?name=smith", "Patient", "", "", false},
+		{"vread", "Patient/123/_history/2", "Patient", "123", "2", false},
+		{"absolute under base", base + "/Observation/abc", "Observation", "abc", "", false},
+		{"absolute other host", "http://other/Patient/9", "Patient", "9", "", false},
+		{"leading slash", "/Patient/5", "Patient", "5", "", false},
+		{"empty", "", "", "", "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rt, id, ver, _, errMsg := parseEntryURL(base, c.raw)
+			if c.wantErr {
+				if errMsg == "" {
+					t.Fatalf("expected error for %q", c.raw)
+				}
+				return
+			}
+			if errMsg != "" {
+				t.Fatalf("unexpected error for %q: %s", c.raw, errMsg)
+			}
+			if rt != c.wantRT || id != c.wantID || ver != c.wantVer {
+				t.Errorf("parseEntryURL(%q) = (%q,%q,%q), want (%q,%q,%q)",
+					c.raw, rt, id, ver, c.wantRT, c.wantID, c.wantVer)
+			}
+		})
+	}
+}
+
+func TestParseEntryURL_Query(t *testing.T) {
+	_, _, _, q, errMsg := parseEntryURL("", "Patient?name=smith&gender=male")
+	if errMsg != "" {
+		t.Fatalf("unexpected error: %s", errMsg)
+	}
+	if q.Get("name") != "smith" || q.Get("gender") != "male" {
+		t.Errorf("query not parsed: %v", q)
+	}
+}
+
+func TestRewriteReferences(t *testing.T) {
+	refMap := map[string]string{
+		"urn:uuid:patient-1": "Patient/p1",
+		"urn:uuid:org-1":     "Organization/o1",
+	}
+	resource := map[string]any{
+		"resourceType": "Observation",
+		"subject":      map[string]any{"reference": "urn:uuid:patient-1"},
+		"performer": []any{
+			map[string]any{"reference": "urn:uuid:org-1"},
+			map[string]any{"reference": "Practitioner/keep-me"},
+		},
+		"note": map[string]any{
+			"author": map[string]any{"reference": "urn:uuid:patient-1"},
+		},
+	}
+
+	rewriteReferences(resource, refMap)
+
+	if got := resource["subject"].(map[string]any)["reference"]; got != "Patient/p1" {
+		t.Errorf("subject.reference = %v, want Patient/p1", got)
+	}
+	perf := resource["performer"].([]any)
+	if got := perf[0].(map[string]any)["reference"]; got != "Organization/o1" {
+		t.Errorf("performer[0].reference = %v, want Organization/o1", got)
+	}
+	if got := perf[1].(map[string]any)["reference"]; got != "Practitioner/keep-me" {
+		t.Errorf("performer[1].reference = %v, should be untouched", got)
+	}
+	if got := resource["note"].(map[string]any)["author"].(map[string]any)["reference"]; got != "Patient/p1" {
+		t.Errorf("nested note.author.reference = %v, want Patient/p1", got)
+	}
+}
+
+func TestMethodOrder(t *testing.T) {
+	// DELETE < POST < PUT < PATCH < GET
+	got := []int{
+		methodOrder("DELETE"),
+		methodOrder("POST"),
+		methodOrder("PUT"),
+		methodOrder("PATCH"),
+		methodOrder("GET"),
+	}
+	want := []int{0, 1, 2, 3, 4}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("methodOrder ordering = %v, want %v", got, want)
+	}
+}
+
+func TestParseETagVersion(t *testing.T) {
+	cases := map[string]struct {
+		want int
+		ok   bool
+	}{
+		`W/"3"`: {3, true},
+		`"5"`:   {5, true},
+		`7`:     {7, true},
+		`W/"x"`: {0, false},
+		``:      {0, false},
+	}
+	for in, exp := range cases {
+		v, ok := parseETagVersion(in)
+		if v != exp.want || ok != exp.ok {
+			t.Errorf("parseETagVersion(%q) = (%d,%v), want (%d,%v)", in, v, ok, exp.want, exp.ok)
+		}
+	}
+}

--- a/miscellaneous/fhir-server-go/internal/store/store.go
+++ b/miscellaneous/fhir-server-go/internal/store/store.go
@@ -33,6 +33,30 @@ func New(pool *pgxpool.Pool, registry *searchparam.Registry) *Store {
 // ─── Create ───────────────────────────────────────────────────────────────────
 
 func (s *Store) Create(ctx context.Context, resourceType string, body map[string]any) (map[string]any, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+
+	result, err := s.createInTx(ctx, tx, resourceType, body)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+
+	id, _ := result["id"].(string)
+	slog.Info("created resource", "type", resourceType, "id", id)
+	return result, nil
+}
+
+// createInTx performs a create within an existing transaction. It is the shared
+// implementation behind the public Create and behind transaction/batch Bundle
+// processing, where many writes must commit or roll back together.
+func (s *Store) createInTx(ctx context.Context, tx pgx.Tx, resourceType string, body map[string]any) (map[string]any, error) {
 	resourceID, _ := body["id"].(string)
 	if resourceID == "" {
 		resourceID = uuid.NewString()
@@ -47,12 +71,6 @@ func (s *Store) Create(ctx context.Context, resourceType string, body map[string
 	if err != nil {
 		return nil, fmt.Errorf("marshal resource: %w", err)
 	}
-
-	tx, err := s.pool.Begin(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback(ctx)
 
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO resources (fhir_id, resource_type, version_id, last_updated, is_deleted, resource_json)
@@ -70,11 +88,6 @@ func (s *Store) Create(ctx context.Context, resourceType string, body map[string
 		return nil, err
 	}
 
-	if err := tx.Commit(ctx); err != nil {
-		return nil, err
-	}
-
-	slog.Info("created resource", "type", resourceType, "id", resourceID)
 	return body, nil
 }
 
@@ -111,14 +124,30 @@ func (s *Store) Read(ctx context.Context, resourceType, resourceID string) (map[
 // any value >= 0 is compared to the current version_id and a ConflictError
 // (412) is returned if they differ.
 func (s *Store) Update(ctx context.Context, resourceType, resourceID string, body map[string]any, ifMatchVersion int) (map[string]any, error) {
-	body["id"] = resourceID
-	body["resourceType"] = resourceType
-
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer tx.Rollback(ctx)
+
+	result, err := s.updateInTx(ctx, tx, resourceType, resourceID, body, ifMatchVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+
+	slog.Info("updated resource", "type", resourceType, "id", resourceID, "version", metaVersionID(result))
+	return result, nil
+}
+
+// updateInTx performs an update within an existing transaction. Shared by the
+// public Update and by transaction/batch Bundle processing.
+func (s *Store) updateInTx(ctx context.Context, tx pgx.Tx, resourceType, resourceID string, body map[string]any, ifMatchVersion int) (map[string]any, error) {
+	body["id"] = resourceID
+	body["resourceType"] = resourceType
 
 	newVersion, currentVersion, lastUpdated, err := bumpVersion(ctx, tx, resourceType, resourceID)
 	if err != nil {
@@ -152,11 +181,6 @@ func (s *Store) Update(ctx context.Context, resourceType, resourceID string, bod
 		return nil, err
 	}
 
-	if err := tx.Commit(ctx); err != nil {
-		return nil, err
-	}
-
-	slog.Info("updated resource", "type", resourceType, "id", resourceID, "version", newVersion)
 	return body, nil
 }
 
@@ -172,6 +196,22 @@ func (s *Store) Patch(ctx context.Context, resourceType, resourceID string, patc
 	}
 	defer tx.Rollback(ctx)
 
+	merged, newVersion, err := s.patchInTx(ctx, tx, resourceType, resourceID, patch)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+
+	slog.Info("patched resource", "type", resourceType, "id", resourceID, "version", newVersion)
+	return merged, nil
+}
+
+// patchInTx applies a JSON Merge Patch within an existing transaction, taking a
+// FOR UPDATE lock on the row. Shared by the public Patch and by Bundle processing.
+func (s *Store) patchInTx(ctx context.Context, tx pgx.Tx, resourceType, resourceID string, patch map[string]any) (map[string]any, int, error) {
 	var raw []byte
 	var versionID int
 	var lastUpdated time.Time
@@ -182,17 +222,17 @@ func (s *Store) Patch(ctx context.Context, resourceType, resourceID string, patc
 		resourceID, resourceType,
 	).Scan(&raw, &versionID, &lastUpdated, &isDeleted); err != nil {
 		if isNoRows(err) {
-			return nil, NotFoundError{resourceType, resourceID}
+			return nil, 0, NotFoundError{resourceType, resourceID}
 		}
-		return nil, err
+		return nil, 0, err
 	}
 	if isDeleted {
-		return nil, GoneError{resourceType, resourceID}
+		return nil, 0, GoneError{resourceType, resourceID}
 	}
 
 	existing, err := unmarshalWithMeta(raw, versionID, lastUpdated)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	merged := mergePatch(existing, patch)
 	merged["id"] = resourceID
@@ -203,7 +243,7 @@ func (s *Store) Patch(ctx context.Context, resourceType, resourceID string, patc
 	merged = setMeta(merged, newVersion, now)
 	mergedRaw, err := json.Marshal(merged)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	if _, err := tx.Exec(ctx, `
@@ -211,23 +251,19 @@ func (s *Store) Patch(ctx context.Context, resourceType, resourceID string, patc
 		WHERE fhir_id = $4 AND resource_type = $5`,
 		newVersion, now, mergedRaw, resourceID, resourceType,
 	); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	if err := index.Delete(ctx, tx, resourceType, resourceID); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	if err := s.extractor.Index(ctx, tx, resourceType, resourceID, merged); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	if err := saveHistory(ctx, tx, resourceType, resourceID, newVersion, "PUT", mergedRaw, now); err != nil {
-		return nil, err
-	}
-	if err := tx.Commit(ctx); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
-	slog.Info("patched resource", "type", resourceType, "id", resourceID, "version", newVersion)
-	return merged, nil
+	return merged, newVersion, nil
 }
 
 // mergePatch applies a JSON Merge Patch (RFC 7396).
@@ -261,6 +297,22 @@ func (s *Store) Delete(ctx context.Context, resourceType, resourceID string) err
 	}
 	defer tx.Rollback(ctx)
 
+	if err := s.deleteInTx(ctx, tx, resourceType, resourceID); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+
+	slog.Info("deleted resource", "type", resourceType, "id", resourceID)
+	return nil
+}
+
+// deleteInTx soft-deletes a resource within an existing transaction. Shared by
+// the public Delete and by Bundle processing. Idempotent: deleting an already
+// deleted or non-existent resource returns nil.
+func (s *Store) deleteInTx(ctx context.Context, tx pgx.Tx, resourceType, resourceID string) error {
 	// Lock the row first to prevent a concurrent Update from bumping the version
 	// between our read and our soft-delete write, which would produce a UNIQUE
 	// constraint violation on resource_history(fhir_id, resource_type, version_id).
@@ -301,11 +353,6 @@ func (s *Store) Delete(ctx context.Context, resourceType, resourceID string) err
 		return err
 	}
 
-	if err := tx.Commit(ctx); err != nil {
-		return err
-	}
-
-	slog.Info("deleted resource", "type", resourceType, "id", resourceID)
 	return nil
 }
 
@@ -420,6 +467,40 @@ func saveHistory(ctx context.Context, tx pgx.Tx, resourceType, resourceID string
 		resourceID, resourceType, versionID, op, raw, ts,
 	)
 	return err
+}
+
+// metaVersionID returns the meta.versionId string of a resource, or "" if absent.
+func metaVersionID(body map[string]any) string {
+	if meta, ok := body["meta"].(map[string]any); ok {
+		if v, ok := meta["versionId"].(string); ok {
+			return v
+		}
+	}
+	return ""
+}
+
+// readInTx reads a live (non-deleted) resource within an existing transaction,
+// so a GET inside a transaction Bundle observes writes made earlier in the same
+// Bundle. Mirrors the public Read but uses the supplied tx instead of the pool.
+func (s *Store) readInTx(ctx context.Context, tx pgx.Tx, resourceType, resourceID string) (map[string]any, error) {
+	var raw []byte
+	var versionID int
+	var lastUpdated time.Time
+	var isDeleted bool
+	if err := tx.QueryRow(ctx, `
+		SELECT resource_json, version_id, last_updated, is_deleted
+		FROM resources WHERE fhir_id = $1 AND resource_type = $2`,
+		resourceID, resourceType,
+	).Scan(&raw, &versionID, &lastUpdated, &isDeleted); err != nil {
+		if isNoRows(err) {
+			return nil, NotFoundError{resourceType, resourceID}
+		}
+		return nil, err
+	}
+	if isDeleted {
+		return nil, GoneError{resourceType, resourceID}
+	}
+	return unmarshalWithMeta(raw, versionID, lastUpdated)
 }
 
 func bumpVersion(ctx context.Context, tx pgx.Tx, resourceType, resourceID string) (newVersion, currentVersion int, lastUpdated time.Time, err error) {


### PR DESCRIPTION
## Summary

The Go FHIR server previously had **no transaction/batch Bundle support** — there was no `POST /fhir/r4` route, so clients could only perform one single-resource interaction per HTTP call. This PR adds the FHIR-standard system-level Bundle endpoint.

Per the [FHIR R4 spec](https://www.hl7.org/fhir/R4/http.html#transaction), a transaction/batch Bundle is `POST`ed to the **base URL** (`/fhir/r4`), and the server dispatches on `Bundle.type`.

## What's included

- **`POST /fhir/r4`** processes `transaction` and `batch` Bundles
  - **transaction** — all entries applied atomically in a single DB transaction; any failure rolls the whole Bundle back and returns a single `OperationOutcome`
  - **batch** — each entry runs independently; a failing entry returns its own `OperationOutcome` without affecting siblings
- Per-entry methods: `POST`, `PUT`, `PATCH` (JSON Merge Patch), `DELETE`, `GET`
- **`urn:uuid` / absolute-URL reference resolution** between entries
- **FHIR verb ordering** (DELETE → POST → PUT/PATCH → GET) so references resolve regardless of entry order
- **Conditional create** (`ifNoneExist`), **conditional update/delete** (query URLs), and **`If-Match`** optimistic locking
- Returns a `transaction-response` / `batch-response` Bundle with `entry.response.{status,location,etag}`
- `CapabilityStatement` now advertises the `transaction` / `batch` interactions

## Refactor

Store CRUD methods now expose transaction-scoped `*InTx` primitives so a Bundle can share one DB transaction; the public `Create/Update/Patch/Delete` are thin wrappers with **unchanged behaviour**.

## Bug fix (found along the way)

Token search params backed by `Identifier` (and `ContactPoint`) were **never indexed** — the extractor only read `code`, but those datatypes carry their token in `value`. It now falls back to `value`, so `?identifier=…` / `?telecom=…` searches match (and identifier-based conditional create works).

## Tests

- 9 new unit tests (URL parsing, reference rewrite, verb order, ETag parse, handler routing/shaping/error mapping)
- 4 new Postgres-backed integration tests (inter-entry references, atomic rollback, batch independence, conditional create)
- Full unit + integration suites pass.

## Known limitations (documented in the README)

- `GET` *search* entries inside a transaction read the committed snapshot (instance reads see in-transaction writes)
- `$validate` remains a stub — resources are not deeply profile-validated before persisting

🤖 Generated with [Claude Code](https://claude.com/claude-code)