### PR TITLE
feat(fhir-server-go): route search params by registry type

### DIFF
--- a/miscellaneous/fhir-server-go/internal/index/extractor.go
+++ b/miscellaneous/fhir-server-go/internal/index/extractor.go
@@ -306,12 +306,11 @@ func indexQuantity(ctx context.Context, tx pgx.Tx, rt, rid, param string, vals [
 		}
 		sys := asString(m["system"])
 		code := asString(m["code"])
-		unit := asString(m["unit"])
 		eps := math.Abs(f) * 1e-7
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO sp_quantity (resource_id, resource_type, param_name, value_low, value_high, system, code, unit)
+			INSERT INTO sp_quantity (resource_id, resource_type, param_name, value, value_low, value_high, system, code)
 			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-			rid, rt, param, f-eps, f+eps, sys, code, unit,
+			rid, rt, param, f, f-eps, f+eps, sys, code,
 		); err != nil {
 			return err
 		}

--- a/miscellaneous/fhir-server-go/internal/store/search.go
+++ b/miscellaneous/fhir-server-go/internal/store/search.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/wso2/open-healthcare-fhir-server-go/internal/searchparam"
 )
 
 // SearchParams are the parsed query parameters from the HTTP request.
@@ -38,7 +39,7 @@ func (s *Store) Search(ctx context.Context, sp SearchParams) (SearchResult, erro
 	}
 	offset := (sp.Page - 1) * sp.PageSize
 
-	b := &queryBuilder{rt: sp.ResourceType}
+	b := &queryBuilder{rt: sp.ResourceType, reg: s.registry}
 	b.writeBase()
 
 	for rawKey, values := range sp.Params {
@@ -112,6 +113,7 @@ func (s *Store) resolveIncludes(ctx context.Context, entries []map[string]any, r
 
 type queryBuilder struct {
 	rt    string
+	reg   *searchparam.Registry
 	where strings.Builder
 	args  []any
 	argN  int
@@ -187,12 +189,48 @@ func (b *queryBuilder) applySearchParam(param, modifier, value string) {
 	}
 }
 
-// buildExistsForValue builds an EXISTS subquery for a single value.
-// Without knowing the param type at query-build time, we do a best-effort
-// guess from the value format. In practice the handler layer can inject
-// the registry lookup; for now string/token cover the common cases.
+// buildExistsForValue builds an EXISTS subquery for a single value, routing to
+// the correct sp_* table by the param's declared type in the registry. When the
+// param is unknown to the registry (e.g. a custom param not yet loaded) it falls
+// back to a best-effort guess from the value format.
 func (b *queryBuilder) buildExistsForValue(param, modifier, value string) (string, bool) {
-	// Heuristic type detection from value format
+	if b.reg != nil {
+		if def, ok := b.reg.Lookup(b.rt, param); ok {
+			return b.buildTypedExists(def.ParamType, param, modifier, value)
+		}
+	}
+	return b.buildHeuristicExists(param, modifier, value)
+}
+
+// buildTypedExists routes a value match to the sp_* table for the given FHIR
+// search param type. Returns (subquery, false) for types we don't yet support
+// (composite, special) so the caller can skip the filter rather than misroute it.
+func (b *queryBuilder) buildTypedExists(paramType, param, modifier, value string) (string, bool) {
+	switch paramType {
+	case "string":
+		return b.buildStringExists(param, modifier, value), true
+	case "token":
+		return b.buildTokenExists(param, modifier, value), true
+	case "date", "dateTime", "instant", "Period":
+		return b.buildDateExists(param, value), true
+	case "number":
+		return b.buildNumberExists(param, value), true
+	case "quantity":
+		return b.buildQuantityExists(param, value), true
+	case "uri":
+		return b.buildURIExists(param, modifier, value), true
+	case "reference":
+		return b.buildReferenceExists(param, modifier, value), true
+	default:
+		// composite / special — not yet supported; skip rather than misroute.
+		return "", false
+	}
+}
+
+// buildHeuristicExists is the legacy value-format guess, used only when the
+// param type is unknown. Reference/quantity/uri params are never reachable here
+// once the registry is loaded.
+func (b *queryBuilder) buildHeuristicExists(param, modifier, value string) (string, bool) {
 	switch {
 	case looksLikeDate(value):
 		return b.buildDateExists(param, value), true
@@ -201,8 +239,8 @@ func (b *queryBuilder) buildExistsForValue(param, modifier, value string) (strin
 	case strings.Contains(value, "|"):
 		return b.buildTokenExists(param, modifier, value), true
 	default:
-		// Without registry type info, match against both sp_string and sp_token so
-		// plain-code token searches (e.g. gender=female) work alongside string params.
+		// Match against both sp_string and sp_token so plain-code token searches
+		// (e.g. gender=female) work alongside string params.
 		strQ := b.buildStringExists(param, modifier, value)
 		tokQ := b.buildTokenExists(param, modifier, value)
 		return strQ + " UNION ALL " + tokQ, true
@@ -298,6 +336,126 @@ func (b *queryBuilder) buildNumberExists(param, value string) string {
 		lowP := b.next(f - eps)
 		return fmt.Sprintf("SELECT 1 FROM sp_number s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND s.value_low <= %s AND s.value_high >= %s", rtP, pP, highP, lowP)
 	}
+}
+
+// buildReferenceExists matches a reference param against sp_reference. It accepts
+// "Type/id", a bare "id", or an absolute URL, and supports the :identifier
+// modifier (patient:identifier=system|value) and an explicit target-type
+// modifier (subject:Patient=123).
+func (b *queryBuilder) buildReferenceExists(param, modifier, value string) string {
+	rtP := b.next(b.rt)
+	pP := b.next(param)
+
+	if modifier == "identifier" {
+		system, val := "", value
+		if i := strings.Index(value, "|"); i >= 0 {
+			system, val = value[:i], value[i+1:]
+		}
+		if system != "" {
+			sP := b.next(system)
+			vP := b.next(val)
+			return fmt.Sprintf("SELECT 1 FROM sp_reference s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND s.identifier_system = %s AND s.identifier_value = %s", rtP, pP, sP, vP)
+		}
+		vP := b.next(val)
+		return fmt.Sprintf("SELECT 1 FROM sp_reference s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND s.identifier_value = %s", rtP, pP, vP)
+	}
+
+	typ, id := parseSearchReference(value)
+	if typ == "" && modifier != "" {
+		// e.g. subject:Patient=123 — the modifier names the target type.
+		typ = modifier
+	}
+	if typ != "" {
+		tP := b.next(typ)
+		iP := b.next(id)
+		return fmt.Sprintf("SELECT 1 FROM sp_reference s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND s.target_type = %s AND s.target_id = %s", rtP, pP, tP, iP)
+	}
+	iP := b.next(id)
+	return fmt.Sprintf("SELECT 1 FROM sp_reference s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND s.target_id = %s", rtP, pP, iP)
+}
+
+// buildQuantityExists matches a quantity param against sp_quantity. The value is
+// "[prefix]number|system|code"; system and code are optional. The third token is
+// matched against the coded (UCUM) unit stored in sp_quantity.code.
+func (b *queryBuilder) buildQuantityExists(param, value string) string {
+	numPart := value
+	var system, code string
+	if parts := strings.SplitN(value, "|", 3); len(parts) > 1 {
+		numPart = parts[0]
+		system = parts[1]
+		if len(parts) == 3 {
+			code = parts[2]
+		}
+	}
+	prefix, numStr := extractComparatorPrefix(numPart)
+	f, _ := strconv.ParseFloat(numStr, 64)
+	eps := math.Abs(f) * 1e-7
+	if eps == 0 {
+		eps = 1e-7
+	}
+	rtP := b.next(b.rt)
+	pP := b.next(param)
+
+	var cond string
+	switch prefix {
+	case "gt":
+		cond = fmt.Sprintf("s.value_high > %s", b.next(f))
+	case "lt":
+		cond = fmt.Sprintf("s.value_low < %s", b.next(f))
+	case "ge":
+		cond = fmt.Sprintf("s.value_high >= %s", b.next(f))
+	case "le":
+		cond = fmt.Sprintf("s.value_low <= %s", b.next(f))
+	case "ne":
+		hP := b.next(f + eps)
+		lP := b.next(f - eps)
+		cond = fmt.Sprintf("NOT (s.value_low <= %s AND s.value_high >= %s)", hP, lP)
+	default: // eq
+		hP := b.next(f + eps)
+		lP := b.next(f - eps)
+		cond = fmt.Sprintf("s.value_low <= %s AND s.value_high >= %s", hP, lP)
+	}
+
+	q := fmt.Sprintf("SELECT 1 FROM sp_quantity s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND %s", rtP, pP, cond)
+	if system != "" {
+		q += fmt.Sprintf(" AND s.system = %s", b.next(system))
+	}
+	if code != "" {
+		q += fmt.Sprintf(" AND s.code = %s", b.next(code))
+	}
+	return q
+}
+
+// buildURIExists matches a uri param against sp_uri (exact match). The :above /
+// :below hierarchy modifiers are not yet handled.
+func (b *queryBuilder) buildURIExists(param, _, value string) string {
+	rtP := b.next(b.rt)
+	pP := b.next(param)
+	vP := b.next(value)
+	return fmt.Sprintf("SELECT 1 FROM sp_uri s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND s.value = %s", rtP, pP, vP)
+}
+
+// parseSearchReference splits a reference search value into (type, id). It
+// accepts "Patient/123", a bare "123", or an absolute URL ending in Type/id,
+// and strips any "/_history/x" version suffix. Mirrors index.parseRefString.
+func parseSearchReference(value string) (resourceType, id string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", ""
+	}
+	if i := strings.Index(value, "/_history/"); i >= 0 {
+		value = value[:i]
+	}
+	if idx := strings.LastIndex(value, "/"); idx >= 0 {
+		pre := value[:idx]
+		if slashIdx := strings.LastIndex(pre, "/"); slashIdx >= 0 {
+			resourceType = pre[slashIdx+1:]
+		} else {
+			resourceType = pre
+		}
+		return resourceType, value[idx+1:]
+	}
+	return "", value
 }
 
 func (b *queryBuilder) applyLastUpdated(value string) {

--- a/miscellaneous/fhir-server-go/internal/store/search.go
+++ b/miscellaneous/fhir-server-go/internal/store/search.go
@@ -158,7 +158,22 @@ func (b *queryBuilder) applyParam(rawKey, value string) {
 
 func (b *queryBuilder) applySearchParam(param, modifier, value string) {
 	if modifier == "missing" {
-		exists := b.spExists("sp_string", param, "")
+		// :missing must look in the table the param was actually indexed into,
+		// otherwise typed params (reference, token, date, quantity, uri) are all
+		// reported as missing. Fall back to sp_string for params the registry
+		// doesn't know.
+		table := "sp_string"
+		if b.reg != nil {
+			if def, ok := b.reg.Lookup(b.rt, param); ok {
+				t := tableForType(def.ParamType)
+				if t == "" {
+					// composite / special — cannot determine presence; skip.
+					return
+				}
+				table = t
+			}
+		}
+		exists := b.spExists(table, param, "")
 		if value == "true" {
 			b.and(fmt.Sprintf("NOT EXISTS (%s)", exists))
 		} else {
@@ -222,8 +237,34 @@ func (b *queryBuilder) buildTypedExists(paramType, param, modifier, value string
 	case "reference":
 		return b.buildReferenceExists(param, modifier, value), true
 	default:
-		// composite / special — not yet supported; skip rather than misroute.
+		// composite / special — not yet supported. Skip rather than misroute,
+		// and surface it so a dropped filter isn't silently treated as a match.
+		slog.Warn("unsupported search param type; filter skipped",
+			"resourceType", b.rt, "param", param, "paramType", paramType)
 		return "", false
+	}
+}
+
+// tableForType maps a FHIR search param type to its sp_* index table. Returns ""
+// for types without a dedicated table (composite, special).
+func tableForType(paramType string) string {
+	switch paramType {
+	case "string":
+		return "sp_string"
+	case "token":
+		return "sp_token"
+	case "date", "dateTime", "instant", "Period":
+		return "sp_date"
+	case "number":
+		return "sp_number"
+	case "quantity":
+		return "sp_quantity"
+	case "uri":
+		return "sp_uri"
+	case "reference":
+		return "sp_reference"
+	default:
+		return ""
 	}
 }
 
@@ -393,26 +434,30 @@ func (b *queryBuilder) buildQuantityExists(param, value string) string {
 	if eps == 0 {
 		eps = 1e-7
 	}
+	low, high := f-eps, f+eps
 	rtP := b.next(b.rt)
 	pP := b.next(param)
 
+	// Compare the indexed range against the search range endpoints (mirrors
+	// buildDateExists) so boundary values are not matched incorrectly — e.g. an
+	// indexed 5 must not satisfy gt5.
 	var cond string
 	switch prefix {
 	case "gt":
-		cond = fmt.Sprintf("s.value_high > %s", b.next(f))
+		cond = fmt.Sprintf("s.value_low > %s", b.next(high))
 	case "lt":
-		cond = fmt.Sprintf("s.value_low < %s", b.next(f))
+		cond = fmt.Sprintf("s.value_high < %s", b.next(low))
 	case "ge":
-		cond = fmt.Sprintf("s.value_high >= %s", b.next(f))
+		cond = fmt.Sprintf("s.value_high >= %s", b.next(low))
 	case "le":
-		cond = fmt.Sprintf("s.value_low <= %s", b.next(f))
+		cond = fmt.Sprintf("s.value_low <= %s", b.next(high))
 	case "ne":
-		hP := b.next(f + eps)
-		lP := b.next(f - eps)
+		hP := b.next(high)
+		lP := b.next(low)
 		cond = fmt.Sprintf("NOT (s.value_low <= %s AND s.value_high >= %s)", hP, lP)
 	default: // eq
-		hP := b.next(f + eps)
-		lP := b.next(f - eps)
+		hP := b.next(high)
+		lP := b.next(low)
 		cond = fmt.Sprintf("s.value_low <= %s AND s.value_high >= %s", hP, lP)
 	}
 

--- a/miscellaneous/fhir-server-go/internal/store/store_integration_test.go
+++ b/miscellaneous/fhir-server-go/internal/store/store_integration_test.go
@@ -550,6 +550,67 @@ func TestSearch_ByQuantityParam(t *testing.T) {
 	if lt.Total != 0 {
 		t.Errorf("expected 0 Encounters for length=lt100, got %d", lt.Total)
 	}
+
+	// Boundary: gt120 must NOT match the encounter whose length is exactly 120.
+	gtBoundary, err := s.Search(ctx, store.SearchParams{
+		ResourceType: "Encounter",
+		Params:       map[string][]string{"length": {"gt120"}},
+	})
+	if err != nil {
+		t.Fatalf("Search by length=gt120: %v", err)
+	}
+	if gtBoundary.Total != 0 {
+		t.Errorf("expected 0 Encounters for length=gt120 (boundary), got %d", gtBoundary.Total)
+	}
+}
+
+func TestSearch_MissingModifier(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+
+	// Observation.subject is a reference param, indexed into sp_reference — the
+	// table :missing previously failed to consult.
+	pat, _ := s.Create(ctx, "Patient", map[string]any{"resourceType": "Patient"})
+	patID := pat["id"].(string)
+
+	withSubject, _ := s.Create(ctx, "Observation", map[string]any{
+		"resourceType": "Observation",
+		"status":       "final",
+		"subject":      map[string]any{"reference": "Patient/" + patID},
+		"code":         map[string]any{"coding": []any{map[string]any{"system": "http://loinc.org", "code": "8310-5"}}},
+	})
+	withID := withSubject["id"].(string)
+
+	noSubject, _ := s.Create(ctx, "Observation", map[string]any{
+		"resourceType": "Observation",
+		"status":       "final",
+		"code":         map[string]any{"coding": []any{map[string]any{"system": "http://loinc.org", "code": "8310-5"}}},
+	})
+	noID := noSubject["id"].(string)
+
+	// subject:missing=true → only the Observation without a subject.
+	missing, err := s.Search(ctx, store.SearchParams{
+		ResourceType: "Observation",
+		Params:       map[string][]string{"subject:missing": {"true"}},
+	})
+	if err != nil {
+		t.Fatalf("Search subject:missing=true: %v", err)
+	}
+	if missing.Total != 1 || missing.Entries[0]["id"] != noID {
+		t.Errorf("subject:missing=true expected only %s, got total=%d", noID, missing.Total)
+	}
+
+	// subject:missing=false → only the Observation with a subject.
+	present, err := s.Search(ctx, store.SearchParams{
+		ResourceType: "Observation",
+		Params:       map[string][]string{"subject:missing": {"false"}},
+	})
+	if err != nil {
+		t.Fatalf("Search subject:missing=false: %v", err)
+	}
+	if present.Total != 1 || present.Entries[0]["id"] != withID {
+		t.Errorf("subject:missing=false expected only %s, got total=%d", withID, present.Total)
+	}
 }
 
 func TestSearch_DeletedResourcesExcluded(t *testing.T) {

--- a/miscellaneous/fhir-server-go/internal/store/store_integration_test.go
+++ b/miscellaneous/fhir-server-go/internal/store/store_integration_test.go
@@ -443,6 +443,115 @@ func TestSearch_ByDateParam(t *testing.T) {
 	}
 }
 
+func TestSearch_ByReferenceParam(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+
+	pat, _ := s.Create(ctx, "Patient", map[string]any{"resourceType": "Patient"})
+	patID := pat["id"].(string)
+
+	obs, _ := s.Create(ctx, "Observation", map[string]any{
+		"resourceType": "Observation",
+		"status":       "final",
+		"subject":      map[string]any{"reference": "Patient/" + patID},
+		"code": map[string]any{
+			"coding": []any{map[string]any{"system": "http://loinc.org", "code": "8310-5"}},
+		},
+	})
+	obsID := obs["id"].(string)
+
+	// An Observation for a different patient that must NOT match.
+	s.Create(ctx, "Observation", map[string]any{
+		"resourceType": "Observation",
+		"status":       "final",
+		"subject":      map[string]any{"reference": "Patient/someone-else"},
+		"code": map[string]any{
+			"coding": []any{map[string]any{"system": "http://loinc.org", "code": "8310-5"}},
+		},
+	})
+
+	// Type/id form: Observation?subject=Patient/<id>
+	result, err := s.Search(ctx, store.SearchParams{
+		ResourceType: "Observation",
+		Params:       map[string][]string{"subject": {"Patient/" + patID}},
+	})
+	if err != nil {
+		t.Fatalf("Search by subject=Patient/id: %v", err)
+	}
+	if result.Total != 1 {
+		t.Fatalf("expected exactly 1 Observation for subject=Patient/%s, got %d", patID, result.Total)
+	}
+	if result.Entries[0]["id"] != obsID {
+		t.Errorf("wrong Observation returned: got %v, want %v", result.Entries[0]["id"], obsID)
+	}
+
+	// Bare id form: Observation?subject=<id>
+	bare, err := s.Search(ctx, store.SearchParams{
+		ResourceType: "Observation",
+		Params:       map[string][]string{"subject": {patID}},
+	})
+	if err != nil {
+		t.Fatalf("Search by subject=<bare id>: %v", err)
+	}
+	if bare.Total != 1 {
+		t.Errorf("expected 1 Observation for subject=%s (bare id), got %d", patID, bare.Total)
+	}
+}
+
+func TestSearch_ByQuantityParam(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+
+	// Encounter.length is a quantity search param (Encounter.length).
+	s.Create(ctx, "Encounter", map[string]any{
+		"resourceType": "Encounter",
+		"status":       "finished",
+		"class":        map[string]any{"system": "http://terminology.hl7.org/CodeSystem/v3-ActCode", "code": "AMB"},
+		"length": map[string]any{
+			"value":  float64(120),
+			"unit":   "min",
+			"system": "http://unitsofmeasure.org",
+			"code":   "min",
+		},
+	})
+
+	// Exact value with system|code.
+	result, err := s.Search(ctx, store.SearchParams{
+		ResourceType: "Encounter",
+		Params:       map[string][]string{"length": {"120|http://unitsofmeasure.org|min"}},
+	})
+	if err != nil {
+		t.Fatalf("Search by length=120|...|min: %v", err)
+	}
+	if result.Total < 1 {
+		t.Errorf("expected ≥1 Encounter for length=120|...|min, got %d", result.Total)
+	}
+
+	// gt prefix.
+	gt, err := s.Search(ctx, store.SearchParams{
+		ResourceType: "Encounter",
+		Params:       map[string][]string{"length": {"gt100"}},
+	})
+	if err != nil {
+		t.Fatalf("Search by length=gt100: %v", err)
+	}
+	if gt.Total < 1 {
+		t.Errorf("expected ≥1 Encounter for length=gt100, got %d", gt.Total)
+	}
+
+	// Non-matching upper bound: lt100 should exclude the 120-min encounter.
+	lt, err := s.Search(ctx, store.SearchParams{
+		ResourceType: "Encounter",
+		Params:       map[string][]string{"length": {"lt100"}},
+	})
+	if err != nil {
+		t.Fatalf("Search by length=lt100: %v", err)
+	}
+	if lt.Total != 0 {
+		t.Errorf("expected 0 Encounters for length=lt100, got %d", lt.Total)
+	}
+}
+
 func TestSearch_DeletedResourcesExcluded(t *testing.T) {
 	s := newStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Purpose

FHIR search previously inferred each parameter's type from the **value's string format** rather than its declared type, misrouting several param types to the wrong `sp_*` tables. Common queries silently returned wrong/empty results — e.g. `Encounter?patient=Patient/123` matched nothing because reference values were looked up in `sp_string`/`sp_token` instead of `sp_reference`. This PR makes search routing type-driven.

Fixes routing for reference, quantity, uri, and identifier (numeric-looking token) searches, and corrects a pre-existing `sp_quantity` indexing bug.

## Goals

- Route every search parameter to the correct index table based on its declared `SearchParameter` type.
- Make reference / quantity / uri searches actually work.
- Keep behaviour unchanged for params the registry doesn't know (custom params).

## Approach

- **Registry-driven dispatch** (`internal/store/search.go`): the query builder now holds the `searchparam.Registry` and looks up each param's `ParamType`, routing to type-specific handlers. The old format-based heuristic is retained only as a fallback for registry-unknown params.
- **New typed builders:** `buildReferenceExists` (→ `sp_reference`; `Type/id`, bare `id`, `:identifier`, `:Type` modifiers), `buildQuantityExists` (→ `sp_quantity`; `value|system|code` with comparator prefixes), `buildURIExists` (→ `sp_uri`), plus `tableForType` so `:missing` consults the right table.
- **Quantity indexing fix** (`internal/index/extractor.go`): the extractor inserted a non-existent `unit` column and omitted the NOT NULL `value` column, so quantity indexing always failed silently. Aligned the INSERT with the schema.
- Unsupported types (composite/special) are skipped with a `slog.Warn` rather than misrouted or silently dropped.

## User stories

- As an API consumer, `GET /Encounter?patient=Patient/123` (and other reference/quantity/uri searches) returns the matching resources instead of an empty bundle.

## Release note

Fixed FHIR search routing so reference, quantity, and URI search parameters return correct results; fixed quantity indexing that previously failed silently.

## Documentation

N/A — no public API/behaviour contract change beyond correctness.

## Automation tests

- Unit: existing helper/handler unit tests pass.
- Integration (Postgres testcontainers): added `TestSearch_ByReferenceParam`, `TestSearch_ByQuantityParam` (incl. `gt120` boundary), and `TestSearch_MissingModifier`; full `store` / `index` / `handler` / `db` integration suites pass.

## Security checks

- No new inputs reach SQL unparameterised — all values continue to be bound via placeholders in the query builder.

## Samples

N/A

## Related PRs

None.

## Migrations

None — `sp_quantity` schema already declared the `value` column; only the extractor INSERT was corrected to match it.

## Test environment

Go + Postgres via testcontainers-go (`-tags integration`).

## Learning

FHIR R4 search parameter types and prefix/range semantics.