### PR TITLE
fhir-server-go: transaction bundles + reference search + capability statement

### DIFF
--- a/miscellaneous/fhir-server-go/README.md
+++ b/miscellaneous/fhir-server-go/README.md
@@ -345,7 +345,7 @@ Track which IG packages have been loaded (for skip-on-restart) and which profile
 | Method | Path | Status | Description |
 |---|---|---|---|
 | `GET` | `/metadata` | 200 | CapabilityStatement |
-| `POST` | `/` (FHIR base) | 200, 400, 4xx | Process a `transaction` / `batch` Bundle |
+| `POST` | `/` (FHIR base) | 200, 400, 4xx, 500 | Process a `transaction` / `batch` Bundle |
 | `GET` | `/{type}/{id}` | 200, 404, 410 | Read resource (410 if soft-deleted) |
 | `GET` | `/{type}/{id}/_history/{vid}` | 200, 400, 404 | Read specific version |
 | `POST` | `/{type}` | 201 | Create resource |
@@ -500,7 +500,7 @@ Supported per-entry methods: `POST`, `PUT`, `PATCH` (JSON Merge Patch), `DELETE`
 
 - **Reference resolution** — within a `transaction`, `urn:uuid:` (and absolute-URL)
   references between entries are rewritten to the server-assigned `Type/id` before
-  persisting. `POST` entries are processed in FHIR verb order (DELETE → POST →
+  persisting. Entries are processed in FHIR verb order (DELETE → POST →
   PUT/PATCH → GET) so references resolve regardless of entry order.
 - **Conditional create** — `entry.request.ifNoneExist` (a search query). If it
   matches one existing resource the create is skipped and the entry resolves to it;

--- a/miscellaneous/fhir-server-go/README.md
+++ b/miscellaneous/fhir-server-go/README.md
@@ -345,6 +345,7 @@ Track which IG packages have been loaded (for skip-on-restart) and which profile
 | Method | Path | Status | Description |
 |---|---|---|---|
 | `GET` | `/metadata` | 200 | CapabilityStatement |
+| `POST` | `/` (FHIR base) | 200, 400, 4xx | Process a `transaction` / `batch` Bundle |
 | `GET` | `/{type}/{id}` | 200, 404, 410 | Read resource (410 if soft-deleted) |
 | `GET` | `/{type}/{id}/_history/{vid}` | 200, 400, 404 | Read specific version |
 | `POST` | `/{type}` | 201 | Create resource |
@@ -455,6 +456,63 @@ curl -X DELETE http://localhost:9090/fhir/r4/Patient/550e8400-e29b-41d4-a716-446
 ```
 
 The resource row is soft-deleted (`is_deleted = TRUE`). Subsequent reads return **410 Gone**.
+
+#### Transaction / Batch Bundle
+
+`POST` a `Bundle` to the FHIR base (`/fhir/r4`). Each `entry.request` carries the
+`method` and `url` the entry would have used as a standalone interaction.
+
+```bash
+curl -X POST http://localhost:9090/fhir/r4 \
+  -H 'Content-Type: application/fhir+json' \
+  -d '{
+    "resourceType": "Bundle",
+    "type": "transaction",
+    "entry": [
+      {
+        "fullUrl": "urn:uuid:pat-1",
+        "resource": { "resourceType": "Patient", "name": [{"family": "Smith"}] },
+        "request": { "method": "POST", "url": "Patient" }
+      },
+      {
+        "resource": {
+          "resourceType": "Observation", "status": "final",
+          "code": { "text": "heart-rate" },
+          "subject": { "reference": "urn:uuid:pat-1" }
+        },
+        "request": { "method": "POST", "url": "Observation" }
+      }
+    ]
+  }'
+```
+
+The response is a `transaction-response` Bundle whose entries carry
+`response.status` / `response.location` / `response.etag`.
+
+**Semantics**
+
+| Bundle type | Atomicity | On entry failure |
+|---|---|---|
+| `transaction` | All entries commit in a **single DB transaction** | Whole Bundle rolls back; a single `OperationOutcome` is returned with the failing entry's status |
+| `batch` | Each entry runs **independently** | Only that entry fails (its `response` carries an `OperationOutcome`); siblings are unaffected; overall status is `200` |
+
+Supported per-entry methods: `POST`, `PUT`, `PATCH` (JSON Merge Patch), `DELETE`, `GET`.
+
+- **Reference resolution** — within a `transaction`, `urn:uuid:` (and absolute-URL)
+  references between entries are rewritten to the server-assigned `Type/id` before
+  persisting. `POST` entries are processed in FHIR verb order (DELETE → POST →
+  PUT/PATCH → GET) so references resolve regardless of entry order.
+- **Conditional create** — `entry.request.ifNoneExist` (a search query). If it
+  matches one existing resource the create is skipped and the entry resolves to it;
+  more than one match is a `412`.
+- **Conditional update / delete** — a `PUT`/`DELETE` whose `request.url` is a search
+  query (e.g. `Patient?identifier=urn:cond|abc`). One match updates/deletes it;
+  zero matches creates (PUT) or no-ops (DELETE); multiple matches is a `412`.
+- **Optimistic locking** — `entry.request.ifMatch` (e.g. `W/"2"`) is honoured on `PUT`.
+
+> **Note:** `GET` search entries inside a `transaction` read the *committed* snapshot
+> and do not observe not-yet-committed writes from earlier entries in the same Bundle.
+> Instance reads (`GET Type/id`) do observe them.
 
 #### Search (GET)
 

--- a/miscellaneous/fhir-server-go/internal/fhirpath/eval.go
+++ b/miscellaneous/fhir-server-go/internal/fhirpath/eval.go
@@ -48,17 +48,18 @@ func Evaluate(expr string, resource map[string]any) ([]any, error) {
 type nodeKind int
 
 const (
-	kindPath      nodeKind = iota // foo.bar.baz
-	kindOfType                    // .ofType(X)
-	kindWhere                     // .where(key='val')
-	kindExists                    // .exists()
-	kindExtension                 // .extension('url')
+	kindPath           nodeKind = iota // foo.bar.baz
+	kindOfType                         // .ofType(X)
+	kindWhere                          // .where(key='val')
+	kindWhereResolveIs                 // .where(resolve() is Type)
+	kindExists                         // .exists()
+	kindExtension                      // .extension('url')
 )
 
 type node struct {
 	kind     nodeKind
 	field    string // for kindPath
-	typeName string // for kindOfType
+	typeName string // for kindOfType, kindWhereResolveIs
 	whereKey string // for kindWhere
 	whereVal string // for kindWhere
 	extURL   string // for kindExtension
@@ -183,6 +184,23 @@ func parseToken(tok string) (node, error) {
 }
 
 func parseWhere(inner string) (node, error) {
+	inner = strings.TrimSpace(inner)
+
+	// resolve() is Type — keep only references whose target is the named type.
+	// Used by many standard params (e.g. patient on Encounter is
+	// "Encounter.subject.where(resolve() is Patient)"). Without this case the
+	// clause falls through to the unsupported branch below and the indexer
+	// extracts nothing for ~50 patient/source/etc. params.
+	if rest, ok := strings.CutPrefix(inner, "resolve()"); ok {
+		rest = strings.TrimSpace(rest)
+		if t, ok := strings.CutPrefix(rest, "is "); ok {
+			typeName := strings.TrimSpace(t)
+			if typeName != "" {
+				return node{kind: kindWhereResolveIs, typeName: typeName}, nil
+			}
+		}
+	}
+
 	// Supports: key = 'value'  or  key != 'value'
 	// "!=" must be checked before "=" to avoid matching the "=" inside "!="
 	for _, sep := range []string{"!=", "="} {
@@ -230,6 +248,9 @@ func applyNode(n node, input any) ([]any, error) {
 
 	case kindWhere:
 		return filterWhere(input, n.whereKey, n.whereVal, n.field), nil
+
+	case kindWhereResolveIs:
+		return filterResolveIs(input, n.typeName), nil
 
 	case kindExists:
 		// exists() returns a boolean — not useful for value extraction; return input as-is
@@ -317,6 +338,32 @@ func filterWhere(input any, key, val, op string) []any {
 		var results []any
 		for _, item := range v {
 			results = append(results, filterWhere(item, key, val, op)...)
+		}
+		return results
+	}
+	return nil
+}
+
+// filterResolveIs implements where(resolve() is TypeName) for Reference inputs.
+// Since indexing has no DB context to actually resolve the reference, we accept
+// a reference whose .reference string is a "TypeName/..." literal (which is how
+// references look after the transaction-bundle rewriter normalises urn:uuid
+// fullUrls into Type/id form). References lacking a typed prefix (e.g. an
+// unresolved "urn:uuid:..." or a bare id) are dropped — correct, because the
+// FHIRPath says "is TypeName" and we cannot prove the target type without
+// fetching it.
+func filterResolveIs(input any, typeName string) []any {
+	prefix := typeName + "/"
+	switch v := input.(type) {
+	case map[string]any:
+		if ref, ok := v["reference"].(string); ok && strings.HasPrefix(ref, prefix) {
+			return []any{v}
+		}
+		return nil
+	case []any:
+		var results []any
+		for _, item := range v {
+			results = append(results, filterResolveIs(item, typeName)...)
 		}
 		return results
 	}

--- a/miscellaneous/fhir-server-go/internal/fhirpath/eval_test.go
+++ b/miscellaneous/fhir-server-go/internal/fhirpath/eval_test.go
@@ -105,6 +105,38 @@ func TestEvaluate_Where_NoMatch(t *testing.T) {
 	}
 }
 
+func TestEvaluate_Where_ResolveIs_Match(t *testing.T) {
+	r := map[string]any{
+		"subject": map[string]any{"reference": "Patient/abc-123"},
+	}
+	got, err := fhirpath.Evaluate("Encounter.subject.where(resolve() is Patient).reference", r)
+	assertNoErr(t, err)
+	assertStrings(t, got, "Patient/abc-123")
+}
+
+func TestEvaluate_Where_ResolveIs_WrongType(t *testing.T) {
+	r := map[string]any{
+		"subject": map[string]any{"reference": "Group/xyz"},
+	}
+	got, err := fhirpath.Evaluate("Encounter.subject.where(resolve() is Patient).reference", r)
+	assertNoErr(t, err)
+	if len(got) != 0 {
+		t.Fatalf("want 0 results for non-Patient subject, got %d: %v", len(got), got)
+	}
+}
+
+func TestEvaluate_Where_ResolveIs_UnresolvedUrnUuid(t *testing.T) {
+	// Pre-bundle-rewrite references can't prove their target type — drop them.
+	r := map[string]any{
+		"subject": map[string]any{"reference": "urn:uuid:abc-123"},
+	}
+	got, err := fhirpath.Evaluate("Encounter.subject.where(resolve() is Patient).reference", r)
+	assertNoErr(t, err)
+	if len(got) != 0 {
+		t.Fatalf("want 0 results for un-typed urn:uuid, got %d: %v", len(got), got)
+	}
+}
+
 func TestEvaluate_Extension(t *testing.T) {
 	r := map[string]any{
 		"extension": []any{

--- a/miscellaneous/fhir-server-go/internal/handler/bundle.go
+++ b/miscellaneous/fhir-server-go/internal/handler/bundle.go
@@ -55,13 +55,17 @@ func (h *fhirHandler) bundle(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		slog.Error("bundle execution failed", "bundleType", bundleType, "err", err)
-		operationOutcome(w, http.StatusInternalServerError, "error", "exception", err.Error())
+		operationOutcome(w, http.StatusInternalServerError, "error", "exception",
+			"unexpected error processing the bundle; see server logs")
 		return
 	}
 
 	// Keep the in-memory SearchParameter registry in sync with any custom
 	// SearchParameters written by the Bundle, mirroring the single-resource path:
-	// create/update re-sync the definition, delete removes it.
+	// create/update re-sync the definition, delete removes it. A sync failure
+	// here means the persisted resource and the in-memory registry are out of
+	// step — log loudly so an operator can spot it; we still return success
+	// because the Bundle itself committed.
 	for _, res := range results {
 		if res.ResourceType != "SearchParameter" {
 			continue
@@ -69,11 +73,17 @@ func (h *fhirHandler) bundle(w http.ResponseWriter, r *http.Request) {
 		switch res.Method {
 		case "POST", "PUT", "PATCH":
 			if res.Resource != nil {
-				_ = h.store.SyncSearchParameter(r.Context(), res.Resource)
+				if serr := h.store.SyncSearchParameter(r.Context(), res.Resource); serr != nil {
+					slog.Error("bundle SearchParameter sync failed; registry may be stale",
+						"method", res.Method, "resourceID", res.ID, "err", serr)
+				}
 			}
 		case "DELETE":
 			if res.ID != "" {
-				_ = h.store.DeleteSearchParameter(r.Context(), res.ID)
+				if serr := h.store.DeleteSearchParameter(r.Context(), res.ID); serr != nil {
+					slog.Error("bundle SearchParameter delete-sync failed; registry may be stale",
+						"resourceID", res.ID, "err", serr)
+				}
 			}
 		}
 	}

--- a/miscellaneous/fhir-server-go/internal/handler/bundle.go
+++ b/miscellaneous/fhir-server-go/internal/handler/bundle.go
@@ -45,6 +45,8 @@ func (h *fhirHandler) bundle(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var be *store.BundleError
 		if errors.As(err, &be) {
+			slog.Error("bundle execution failed", "bundleType", bundleType,
+				"entryIndex", be.EntryIndex, "status", be.HTTPStatus, "err", be.Diagnostics)
 			diag := be.Diagnostics
 			if be.EntryIndex >= 0 {
 				diag = fmt.Sprintf("entry[%d]: %s", be.EntryIndex, be.Diagnostics)
@@ -52,16 +54,26 @@ func (h *fhirHandler) bundle(w http.ResponseWriter, r *http.Request) {
 			operationOutcome(w, be.HTTPStatus, "error", be.Code, diag)
 			return
 		}
+		slog.Error("bundle execution failed", "bundleType", bundleType, "err", err)
 		operationOutcome(w, http.StatusInternalServerError, "error", "exception", err.Error())
 		return
 	}
 
 	// Keep the in-memory SearchParameter registry in sync with any custom
-	// SearchParameters written by the Bundle, mirroring the single-resource path.
+	// SearchParameters written by the Bundle, mirroring the single-resource path:
+	// create/update re-sync the definition, delete removes it.
 	for _, res := range results {
-		if res.Resource != nil {
-			if rt, _ := res.Resource["resourceType"].(string); rt == "SearchParameter" {
+		if res.ResourceType != "SearchParameter" {
+			continue
+		}
+		switch res.Method {
+		case "POST", "PUT", "PATCH":
+			if res.Resource != nil {
 				_ = h.store.SyncSearchParameter(r.Context(), res.Resource)
+			}
+		case "DELETE":
+			if res.ID != "" {
+				_ = h.store.DeleteSearchParameter(r.Context(), res.ID)
 			}
 		}
 	}

--- a/miscellaneous/fhir-server-go/internal/handler/bundle.go
+++ b/miscellaneous/fhir-server-go/internal/handler/bundle.go
@@ -1,0 +1,162 @@
+package handler
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/wso2/open-healthcare-fhir-server-go/internal/store"
+)
+
+// bundle handles POST /fhir/r4 — a system-level transaction or batch Bundle.
+func (h *fhirHandler) bundle(w http.ResponseWriter, r *http.Request) {
+	if !requireFHIRContent(w, r) {
+		return
+	}
+
+	body, err := readBody(r)
+	if err != nil {
+		operationOutcome(w, http.StatusBadRequest, "error", "invalid", "invalid JSON: "+err.Error())
+		return
+	}
+
+	if rt, _ := body["resourceType"].(string); rt != "Bundle" {
+		operationOutcome(w, http.StatusBadRequest, "error", "invalid",
+			"request body must be a Bundle resource")
+		return
+	}
+
+	bundleType, _ := body["type"].(string)
+	if bundleType != "transaction" && bundleType != "batch" {
+		operationOutcome(w, http.StatusBadRequest, "error", "value",
+			fmt.Sprintf("Bundle.type must be 'transaction' or 'batch', got %q", bundleType))
+		return
+	}
+
+	entries, perr := parseBundleEntries(body)
+	if perr != "" {
+		operationOutcome(w, http.StatusBadRequest, "error", "value", perr)
+		return
+	}
+
+	results, err := h.store.ExecuteBundle(r.Context(), bundleType, h.baseURL, entries)
+	if err != nil {
+		var be *store.BundleError
+		if errors.As(err, &be) {
+			diag := be.Diagnostics
+			if be.EntryIndex >= 0 {
+				diag = fmt.Sprintf("entry[%d]: %s", be.EntryIndex, be.Diagnostics)
+			}
+			operationOutcome(w, be.HTTPStatus, "error", be.Code, diag)
+			return
+		}
+		operationOutcome(w, http.StatusInternalServerError, "error", "exception", err.Error())
+		return
+	}
+
+	// Keep the in-memory SearchParameter registry in sync with any custom
+	// SearchParameters written by the Bundle, mirroring the single-resource path.
+	for _, res := range results {
+		if res.Resource != nil {
+			if rt, _ := res.Resource["resourceType"].(string); rt == "SearchParameter" {
+				_ = h.store.SyncSearchParameter(r.Context(), res.Resource)
+			}
+		}
+	}
+
+	responseType := "transaction-response"
+	if bundleType == "batch" {
+		responseType = "batch-response"
+	}
+	writeJSON(w, http.StatusOK, h.buildBundleResponse(responseType, results))
+}
+
+// buildBundleResponse assembles the transaction-response / batch-response Bundle.
+func (h *fhirHandler) buildBundleResponse(responseType string, results []store.BundleEntryResult) map[string]any {
+	entries := make([]any, 0, len(results))
+	for _, res := range results {
+		response := map[string]any{"status": res.Status}
+		if res.Location != "" {
+			response["location"] = h.absoluteLocation(res.Location)
+		}
+		if res.ETag != "" {
+			response["etag"] = res.ETag
+		}
+		if res.Outcome != nil {
+			response["outcome"] = res.Outcome
+		}
+
+		entry := map[string]any{"response": response}
+		if res.Resource != nil {
+			entry["resource"] = res.Resource
+		}
+		entries = append(entries, entry)
+	}
+
+	return map[string]any{
+		"resourceType": "Bundle",
+		"type":         responseType,
+		"entry":        entries,
+	}
+}
+
+// absoluteLocation turns a relative "Type/id/_history/v" location into an
+// absolute URL under the server base.
+func (h *fhirHandler) absoluteLocation(loc string) string {
+	if strings.Contains(loc, "://") {
+		return loc
+	}
+	return strings.TrimRight(h.baseURL, "/") + "/" + strings.TrimLeft(loc, "/")
+}
+
+// parseBundleEntries converts the raw Bundle.entry array into typed store
+// requests. It returns a non-empty error string on a malformed Bundle.
+func parseBundleEntries(bundle map[string]any) ([]store.BundleEntryRequest, string) {
+	rawEntries, ok := bundle["entry"].([]any)
+	if !ok {
+		// An empty Bundle is valid — nothing to process.
+		return nil, ""
+	}
+
+	entries := make([]store.BundleEntryRequest, 0, len(rawEntries))
+	for i, raw := range rawEntries {
+		entryMap, ok := raw.(map[string]any)
+		if !ok {
+			return nil, fmt.Sprintf("entry[%d] is not an object", i)
+		}
+
+		req, ok := entryMap["request"].(map[string]any)
+		if !ok {
+			return nil, fmt.Sprintf("entry[%d].request is required for transaction/batch", i)
+		}
+
+		method, _ := req["method"].(string)
+		url, _ := req["url"].(string)
+		if method == "" || url == "" {
+			return nil, fmt.Sprintf("entry[%d].request.method and request.url are required", i)
+		}
+
+		entry := store.BundleEntryRequest{
+			Method:      method,
+			URL:         url,
+			IfMatch:     stringField(req, "ifMatch"),
+			IfNoneExist: stringField(req, "ifNoneExist"),
+			FullURL:     stringField(entryMap, "fullUrl"),
+		}
+		if resource, ok := entryMap["resource"].(map[string]any); ok {
+			entry.Resource = resource
+		}
+		entries = append(entries, entry)
+	}
+	slog.Debug("parsed bundle entries", "count", len(entries))
+	return entries, ""
+}
+
+func stringField(m map[string]any, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}

--- a/miscellaneous/fhir-server-go/internal/handler/bundle_integration_test.go
+++ b/miscellaneous/fhir-server-go/internal/handler/bundle_integration_test.go
@@ -1,0 +1,245 @@
+//go:build integration
+
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// ─── Transaction: create with inter-entry reference resolution ─────────────────
+
+func TestIntegration_Transaction_CreateWithReferences(t *testing.T) {
+	srv := newRealServer(t)
+
+	bundle := map[string]any{
+		"resourceType": "Bundle",
+		"type":         "transaction",
+		"entry": []any{
+			map[string]any{
+				"fullUrl":  "urn:uuid:patient-1",
+				"resource": map[string]any{"resourceType": "Patient", "name": []any{map[string]any{"family": "Tx"}}},
+				"request":  map[string]any{"method": "POST", "url": "Patient"},
+			},
+			map[string]any{
+				"fullUrl": "urn:uuid:obs-1",
+				"resource": map[string]any{
+					"resourceType": "Observation",
+					"status":       "final",
+					"code":         map[string]any{"text": "hr"},
+					"subject":      map[string]any{"reference": "urn:uuid:patient-1"},
+				},
+				"request": map[string]any{"method": "POST", "url": "Observation"},
+			},
+		},
+	}
+
+	resp := iDo(t, srv, http.MethodPost, "/fhir/r4", bundle)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("transaction: want 200, got %d", resp.StatusCode)
+	}
+	body := iJSON(t, resp)
+	if body["type"] != "transaction-response" {
+		t.Fatalf("want transaction-response, got %v", body["type"])
+	}
+	entries := body["entry"].([]any)
+	if len(entries) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(entries))
+	}
+
+	// Both entries created.
+	for i, e := range entries {
+		resp := e.(map[string]any)["response"].(map[string]any)
+		if resp["status"] != "201 Created" {
+			t.Errorf("entry[%d] status = %v, want 201 Created", i, resp["status"])
+		}
+	}
+
+	// The Observation's subject reference must have been rewritten to Patient/<id>.
+	patientLoc := entries[0].(map[string]any)["response"].(map[string]any)["location"].(string)
+	patientID := lastPathID(patientLoc)
+	obs := entries[1].(map[string]any)["resource"].(map[string]any)
+	gotRef := obs["subject"].(map[string]any)["reference"].(string)
+	wantRef := "Patient/" + patientID
+	if gotRef != wantRef {
+		t.Errorf("subject.reference = %q, want %q", gotRef, wantRef)
+	}
+
+	// The Patient is actually retrievable.
+	rd := iDo(t, srv, http.MethodGet, "/fhir/r4/Patient/"+patientID, nil)
+	if rd.StatusCode != http.StatusOK {
+		t.Fatalf("read created Patient: want 200, got %d", rd.StatusCode)
+	}
+	rd.Body.Close()
+}
+
+// ─── Transaction: atomic rollback ──────────────────────────────────────────────
+
+func TestIntegration_Transaction_RollsBackOnError(t *testing.T) {
+	srv := newRealServer(t)
+
+	bundle := map[string]any{
+		"resourceType": "Bundle",
+		"type":         "transaction",
+		"entry": []any{
+			map[string]any{
+				"fullUrl":  "urn:uuid:good",
+				"resource": map[string]any{"resourceType": "Patient", "name": []any{map[string]any{"family": "ShouldNotPersist"}}},
+				"request":  map[string]any{"method": "POST", "url": "Patient"},
+			},
+			// This entry fails: PUT to a non-existent id WITH an If-Match guard,
+			// which cannot create and must error → whole transaction rolls back.
+			map[string]any{
+				"resource": map[string]any{"resourceType": "Patient", "id": "definitely-missing"},
+				"request": map[string]any{
+					"method":  "PUT",
+					"url":     "Patient/definitely-missing",
+					"ifMatch": "W/\"9\"",
+				},
+			},
+		},
+	}
+
+	resp := iDo(t, srv, http.MethodPost, "/fhir/r4", bundle)
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("expected transaction to fail, got 200")
+	}
+	body := iJSON(t, resp)
+	if body["resourceType"] != "OperationOutcome" {
+		t.Fatalf("want OperationOutcome on failure, got %v", body["resourceType"])
+	}
+
+	// The good Patient must NOT have been persisted (full rollback).
+	search := iDo(t, srv, http.MethodGet, "/fhir/r4/Patient?family=ShouldNotPersist", nil)
+	sbody := iJSON(t, search)
+	if total, _ := sbody["total"].(float64); total != 0 {
+		t.Errorf("rollback failed: found %v Patients that should not exist", total)
+	}
+}
+
+// ─── Batch: independent entries ────────────────────────────────────────────────
+
+func TestIntegration_Batch_IndependentEntries(t *testing.T) {
+	srv := newRealServer(t)
+
+	bundle := map[string]any{
+		"resourceType": "Bundle",
+		"type":         "batch",
+		"entry": []any{
+			map[string]any{
+				"resource": map[string]any{"resourceType": "Patient", "name": []any{map[string]any{"family": "BatchGood"}}},
+				"request":  map[string]any{"method": "POST", "url": "Patient"},
+			},
+			// Fails (404) but must not affect the good entry.
+			map[string]any{
+				"request": map[string]any{"method": "GET", "url": "Patient/does-not-exist"},
+			},
+		},
+	}
+
+	resp := iDo(t, srv, http.MethodPost, "/fhir/r4", bundle)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("batch: want 200 overall, got %d", resp.StatusCode)
+	}
+	body := iJSON(t, resp)
+	if body["type"] != "batch-response" {
+		t.Fatalf("want batch-response, got %v", body["type"])
+	}
+	entries := body["entry"].([]any)
+	if len(entries) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(entries))
+	}
+
+	r0 := entries[0].(map[string]any)["response"].(map[string]any)
+	if r0["status"] != "201 Created" {
+		t.Errorf("entry[0] status = %v, want 201 Created", r0["status"])
+	}
+	r1 := entries[1].(map[string]any)["response"].(map[string]any)
+	if status, _ := r1["status"].(string); status[:3] != "404" {
+		t.Errorf("entry[1] status = %v, want 404", r1["status"])
+	}
+
+	// The good Patient persisted despite the sibling failure.
+	search := iDo(t, srv, http.MethodGet, "/fhir/r4/Patient?family=BatchGood", nil)
+	sbody := iJSON(t, search)
+	if total, _ := sbody["total"].(float64); total != 1 {
+		t.Errorf("want 1 BatchGood Patient, got %v", total)
+	}
+}
+
+// ─── Transaction: conditional create (If-None-Exist) ───────────────────────────
+
+func TestIntegration_Transaction_ConditionalCreate(t *testing.T) {
+	srv := newRealServer(t)
+
+	// Seed a Patient with a unique identifier.
+	id, _ := iCreate(t, srv, "Patient", map[string]any{
+		"resourceType": "Patient",
+		"identifier":   []any{map[string]any{"system": "urn:cond", "value": "abc"}},
+	})
+
+	bundle := map[string]any{
+		"resourceType": "Bundle",
+		"type":         "transaction",
+		"entry": []any{
+			map[string]any{
+				"resource": map[string]any{
+					"resourceType": "Patient",
+					"identifier":   []any{map[string]any{"system": "urn:cond", "value": "abc"}},
+				},
+				"request": map[string]any{
+					"method":      "POST",
+					"url":         "Patient",
+					"ifNoneExist": "identifier=urn:cond|abc",
+				},
+			},
+		},
+	}
+
+	resp := iDo(t, srv, http.MethodPost, "/fhir/r4", bundle)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("conditional create: want 200, got %d", resp.StatusCode)
+	}
+	body := iJSON(t, resp)
+	entry := body["entry"].([]any)[0].(map[string]any)["response"].(map[string]any)
+	// Matched the existing one → 200, not a new create, pointing at the seeded id.
+	if entry["status"] != "200 OK" {
+		t.Errorf("status = %v, want 200 OK (matched existing)", entry["status"])
+	}
+	if loc, _ := entry["location"].(string); lastPathID(loc) != id {
+		t.Errorf("conditional create should reuse existing id %s, got location %v", id, loc)
+	}
+}
+
+// lastPathID returns the id segment of a location like ".../Patient/<id>/_history/1".
+func lastPathID(loc string) string {
+	parts := splitNonEmpty(loc, '/')
+	for i, p := range parts {
+		if p == "_history" && i > 0 {
+			return parts[i-1]
+		}
+	}
+	if len(parts) > 0 {
+		return parts[len(parts)-1]
+	}
+	return ""
+}
+
+func splitNonEmpty(s string, sep byte) []string {
+	var out []string
+	cur := ""
+	for i := 0; i < len(s); i++ {
+		if s[i] == sep {
+			if cur != "" {
+				out = append(out, cur)
+			}
+			cur = ""
+		} else {
+			cur += string(s[i])
+		}
+	}
+	if cur != "" {
+		out = append(out, cur)
+	}
+	return out
+}

--- a/miscellaneous/fhir-server-go/internal/handler/bundle_integration_test.go
+++ b/miscellaneous/fhir-server-go/internal/handler/bundle_integration_test.go
@@ -4,7 +4,15 @@ package handler_test
 
 import (
 	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
+
+	"github.com/wso2/open-healthcare-fhir-server-go/internal/handler"
+	"github.com/wso2/open-healthcare-fhir-server-go/internal/searchparam"
+	"github.com/wso2/open-healthcare-fhir-server-go/internal/store"
+	"github.com/wso2/open-healthcare-fhir-server-go/internal/testutil"
 )
 
 // ─── Transaction: create with inter-entry reference resolution ─────────────────
@@ -155,7 +163,7 @@ func TestIntegration_Batch_IndependentEntries(t *testing.T) {
 		t.Errorf("entry[0] status = %v, want 201 Created", r0["status"])
 	}
 	r1 := entries[1].(map[string]any)["response"].(map[string]any)
-	if status, _ := r1["status"].(string); status[:3] != "404" {
+	if status, _ := r1["status"].(string); !strings.HasPrefix(status, "404") {
 		t.Errorf("entry[1] status = %v, want 404", r1["status"])
 	}
 
@@ -208,6 +216,57 @@ func TestIntegration_Transaction_ConditionalCreate(t *testing.T) {
 	}
 	if loc, _ := entry["location"].(string); lastPathID(loc) != id {
 		t.Errorf("conditional create should reuse existing id %s, got location %v", id, loc)
+	}
+}
+
+// ─── Transaction: SearchParameter DELETE cleans up the registry ────────────────
+
+// newServerWithRegistry builds a real server but also returns the registry so a
+// test can assert custom SearchParameter definitions are added/removed.
+func newServerWithRegistry(t *testing.T) (*httptest.Server, *searchparam.Registry) {
+	t.Helper()
+	pool := testutil.MustSeededDB(t)
+	reg := testutil.MustRegistry(t, pool)
+	s := store.New(pool, reg)
+	var ready atomic.Int32
+	ready.Store(1)
+	srv := httptest.NewServer(handler.NewRouter(s, pool, reg, "http://test-server/fhir/r4", &ready))
+	t.Cleanup(srv.Close)
+	return srv, reg
+}
+
+func TestIntegration_Transaction_SearchParameterDeleteCleansUpRegistry(t *testing.T) {
+	srv, reg := newServerWithRegistry(t)
+
+	// Create a custom SearchParameter directly so it lands in the registry.
+	id, _ := iCreate(t, srv, "SearchParameter", map[string]any{
+		"resourceType": "SearchParameter",
+		"code":         "bundle-custom",
+		"base":         []any{"Patient"},
+		"type":         "string",
+		"expression":   "Patient.extension('http://example.com/bundle-custom')",
+	})
+	if _, ok := reg.Lookup("Patient", "bundle-custom"); !ok {
+		t.Fatal("custom SearchParameter should be in the registry after create")
+	}
+
+	// Delete it via a transaction Bundle. Before the fix, the Bundle path never
+	// called DeleteSearchParameter, so the registry/definition leaked.
+	bundle := map[string]any{
+		"resourceType": "Bundle",
+		"type":         "transaction",
+		"entry": []any{map[string]any{
+			"request": map[string]any{"method": "DELETE", "url": "SearchParameter/" + id},
+		}},
+	}
+	resp := iDo(t, srv, http.MethodPost, "/fhir/r4", bundle)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("transaction delete: want 200, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	if _, ok := reg.Lookup("Patient", "bundle-custom"); ok {
+		t.Error("custom SearchParameter should be removed from the registry after Bundle DELETE")
 	}
 }
 

--- a/miscellaneous/fhir-server-go/internal/handler/bundle_test.go
+++ b/miscellaneous/fhir-server-go/internal/handler/bundle_test.go
@@ -1,0 +1,116 @@
+package handler_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/wso2/open-healthcare-fhir-server-go/internal/store"
+)
+
+func TestBundle_RoutesAndShapesTransactionResponse(t *testing.T) {
+	ms := &mockStore{
+		executeBundleFn: func(_ context.Context, bundleType, baseURL string, entries []store.BundleEntryRequest) ([]store.BundleEntryResult, error) {
+			if bundleType != "transaction" {
+				t.Errorf("bundleType = %q, want transaction", bundleType)
+			}
+			if len(entries) != 1 || entries[0].Method != "POST" {
+				t.Errorf("entries not parsed: %+v", entries)
+			}
+			return []store.BundleEntryResult{{
+				Status:   "201 Created",
+				Location: "Patient/123/_history/1",
+				ETag:     `W/"1"`,
+				Resource: map[string]any{"resourceType": "Patient", "id": "123"},
+			}}, nil
+		},
+	}
+	h := newRouter(ms)
+
+	resp := do(t, h, http.MethodPost, "/fhir/r4", map[string]any{
+		"resourceType": "Bundle",
+		"type":         "transaction",
+		"entry": []any{map[string]any{
+			"resource": map[string]any{"resourceType": "Patient"},
+			"request":  map[string]any{"method": "POST", "url": "Patient"},
+		}},
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", resp.Code, resp.Body.String())
+	}
+	body := decodeJSON(t, resp)
+	if body["type"] != "transaction-response" {
+		t.Errorf("type = %v, want transaction-response", body["type"])
+	}
+	entries, _ := body["entry"].([]any)
+	if len(entries) != 1 {
+		t.Fatalf("want 1 response entry, got %d", len(entries))
+	}
+	respObj := entries[0].(map[string]any)["response"].(map[string]any)
+	if respObj["status"] != "201 Created" {
+		t.Errorf("status = %v, want 201 Created", respObj["status"])
+	}
+	// Location must be made absolute under the server base.
+	if respObj["location"] != "http://localhost:9090/fhir/r4/Patient/123/_history/1" {
+		t.Errorf("location = %v, want absolute", respObj["location"])
+	}
+}
+
+func TestBundle_RejectsNonBundle(t *testing.T) {
+	h := newRouter(&mockStore{})
+	resp := do(t, h, http.MethodPost, "/fhir/r4", map[string]any{"resourceType": "Patient"})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.Code)
+	}
+}
+
+func TestBundle_RejectsBadType(t *testing.T) {
+	h := newRouter(&mockStore{})
+	resp := do(t, h, http.MethodPost, "/fhir/r4", map[string]any{
+		"resourceType": "Bundle",
+		"type":         "collection",
+	})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for non-transaction/batch type", resp.Code)
+	}
+}
+
+func TestBundle_TransactionErrorMapsStatus(t *testing.T) {
+	ms := &mockStore{
+		executeBundleFn: func(_ context.Context, _, _ string, _ []store.BundleEntryRequest) ([]store.BundleEntryResult, error) {
+			return nil, &store.BundleError{HTTPStatus: 404, Code: "not-found", EntryIndex: 0, Diagnostics: "Patient/x not found"}
+		},
+	}
+	h := newRouter(ms)
+	resp := do(t, h, http.MethodPost, "/fhir/r4", map[string]any{
+		"resourceType": "Bundle",
+		"type":         "transaction",
+		"entry": []any{map[string]any{
+			"request": map[string]any{"method": "DELETE", "url": "Patient/x"},
+		}},
+	})
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.Code)
+	}
+	body := decodeJSON(t, resp)
+	if body["resourceType"] != "OperationOutcome" {
+		t.Errorf("want OperationOutcome, got %v", body["resourceType"])
+	}
+}
+
+func TestBundle_TrailingSlashAlsoRoutes(t *testing.T) {
+	called := false
+	ms := &mockStore{
+		executeBundleFn: func(_ context.Context, _, _ string, _ []store.BundleEntryRequest) ([]store.BundleEntryResult, error) {
+			called = true
+			return []store.BundleEntryResult{}, nil
+		},
+	}
+	h := newRouter(ms)
+	resp := do(t, h, http.MethodPost, "/fhir/r4/", map[string]any{
+		"resourceType": "Bundle", "type": "batch",
+	})
+	if resp.Code != http.StatusOK || !called {
+		t.Fatalf("trailing-slash POST did not route to bundle handler: status=%d called=%v", resp.Code, called)
+	}
+}

--- a/miscellaneous/fhir-server-go/internal/handler/handler_integration_test.go
+++ b/miscellaneous/fhir-server-go/internal/handler/handler_integration_test.go
@@ -638,3 +638,66 @@ func TestMetadata_ListsFullR4ResourceSet(t *testing.T) {
 		}
 	}
 }
+
+// TestMetadata_AdvertisesSearchParams verifies each rest.resource entry carries
+// a populated searchParam list sourced from the registry, and that reference
+// params are projected into searchInclude. Capability-driven clients (SMART
+// launchers, generic explorers) rely on this for param discovery.
+func TestMetadata_AdvertisesSearchParams(t *testing.T) {
+	srv := newRealServer(t)
+	resp := iDo(t, srv, http.MethodGet, "/fhir/r4/metadata", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	cs := iJSON(t, resp)
+	rest, _ := cs["rest"].([]any)
+	rest0, _ := rest[0].(map[string]any)
+	resources, _ := rest0["resource"].([]any)
+
+	byType := map[string]map[string]any{}
+	for _, r := range resources {
+		e, _ := r.(map[string]any)
+		if rt, ok := e["type"].(string); ok {
+			byType[rt] = e
+		}
+	}
+
+	enc, ok := byType["Encounter"]
+	if !ok {
+		t.Fatal("Encounter missing from CapabilityStatement")
+	}
+	sps, _ := enc["searchParam"].([]any)
+	if len(sps) == 0 {
+		t.Fatal("Encounter.searchParam is empty — registry contents not projected")
+	}
+
+	// Spot-check that "patient" is present and typed as reference.
+	var foundPatient bool
+	for _, p := range sps {
+		m, _ := p.(map[string]any)
+		if m["name"] == "patient" {
+			foundPatient = true
+			if m["type"] != "reference" {
+				t.Errorf("Encounter.searchParam[patient].type = %v, want reference", m["type"])
+			}
+		}
+	}
+	if !foundPatient {
+		t.Error("Encounter.searchParam is missing 'patient'")
+	}
+
+	// searchInclude should at minimum list reference params on this resource.
+	incs, _ := enc["searchInclude"].([]any)
+	if len(incs) == 0 {
+		t.Fatal("Encounter.searchInclude is empty — reference params not projected as _include targets")
+	}
+	var foundEncPatient bool
+	for _, v := range incs {
+		if s, _ := v.(string); s == "Encounter:patient" {
+			foundEncPatient = true
+		}
+	}
+	if !foundEncPatient {
+		t.Errorf("Encounter.searchInclude missing 'Encounter:patient'; got %v", incs)
+	}
+}

--- a/miscellaneous/fhir-server-go/internal/handler/handler_test.go
+++ b/miscellaneous/fhir-server-go/internal/handler/handler_test.go
@@ -28,6 +28,7 @@ type mockStore struct {
 	fetchReferencesFn   func(ctx context.Context, rt, id string, reverse bool) ([]map[string]any, error)
 	syncSearchParamFn   func(ctx context.Context, body map[string]any) error
 	deleteSearchParamFn func(ctx context.Context, id string) error
+	executeBundleFn     func(ctx context.Context, bundleType, baseURL string, entries []store.BundleEntryRequest) ([]store.BundleEntryResult, error)
 }
 
 func (m *mockStore) Read(ctx context.Context, rt, id string) (map[string]any, error) {
@@ -74,6 +75,12 @@ func (m *mockStore) DeleteSearchParameter(ctx context.Context, id string) error 
 		return m.deleteSearchParamFn(ctx, id)
 	}
 	return nil
+}
+func (m *mockStore) ExecuteBundle(ctx context.Context, bundleType, baseURL string, entries []store.BundleEntryRequest) ([]store.BundleEntryResult, error) {
+	if m.executeBundleFn != nil {
+		return m.executeBundleFn(ctx, bundleType, baseURL, entries)
+	}
+	return nil, nil
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/miscellaneous/fhir-server-go/internal/handler/handlers.go
+++ b/miscellaneous/fhir-server-go/internal/handler/handlers.go
@@ -695,8 +695,12 @@ func (h *fhirHandler) metadata(w http.ResponseWriter, r *http.Request) {
 			"version": "1.0.0",
 		},
 		"rest": []any{map[string]any{
-			"mode":      "server",
-			"resource":  resources,
+			"mode":     "server",
+			"resource": resources,
+			"interaction": []any{
+				map[string]any{"code": "transaction"},
+				map[string]any{"code": "batch"},
+			},
 			"operation": []any{map[string]any{"name": "everything", "definition": "http://hl7.org/fhir/OperationDefinition/Patient-everything"}},
 		}},
 	}

--- a/miscellaneous/fhir-server-go/internal/handler/handlers.go
+++ b/miscellaneous/fhir-server-go/internal/handler/handlers.go
@@ -680,6 +680,32 @@ func (h *fhirHandler) metadata(w http.ResponseWriter, r *http.Request) {
 		if profs, ok := profiles[rt]; ok && len(profs) > 0 {
 			entry["supportedProfile"] = profs
 		}
+
+		// searchParam: every param the registry knows for this resource type.
+		// searchInclude: reference params can be used as _include targets.
+		// (searchRevInclude is intentionally omitted — it requires per-param
+		// target-type knowledge the registry's FHIRPath strings don't carry
+		// reliably for un-filtered refs like "Encounter.subject".)
+		if h.registry != nil {
+			defs := h.registry.ForResource(rt)
+			if len(defs) > 0 {
+				sps := make([]any, 0, len(defs))
+				var includes []string
+				for _, d := range defs {
+					sps = append(sps, map[string]any{
+						"name": d.ParamName,
+						"type": d.ParamType,
+					})
+					if d.ParamType == "reference" {
+						includes = append(includes, rt+":"+d.ParamName)
+					}
+				}
+				entry["searchParam"] = sps
+				if len(includes) > 0 {
+					entry["searchInclude"] = includes
+				}
+			}
+		}
 		resources = append(resources, entry)
 	}
 

--- a/miscellaneous/fhir-server-go/internal/handler/handlers.go
+++ b/miscellaneous/fhir-server-go/internal/handler/handlers.go
@@ -160,6 +160,11 @@ func (h *fhirHandler) search(w http.ResponseWriter, r *http.Request) {
 		PageSize:     pageSize,
 	})
 	if err != nil {
+		var unsup *store.UnsupportedParamError
+		if errors.As(err, &unsup) {
+			operationOutcome(w, http.StatusBadRequest, "error", "not-supported", unsup.Msg)
+			return
+		}
 		operationOutcome(w, http.StatusInternalServerError, "error", "exception", err.Error())
 		return
 	}
@@ -196,6 +201,11 @@ func (h *fhirHandler) searchPost(w http.ResponseWriter, r *http.Request) {
 		PageSize:     pageSize,
 	})
 	if err != nil {
+		var unsup *store.UnsupportedParamError
+		if errors.As(err, &unsup) {
+			operationOutcome(w, http.StatusBadRequest, "error", "not-supported", unsup.Msg)
+			return
+		}
 		operationOutcome(w, http.StatusInternalServerError, "error", "exception", err.Error())
 		return
 	}

--- a/miscellaneous/fhir-server-go/internal/handler/router.go
+++ b/miscellaneous/fhir-server-go/internal/handler/router.go
@@ -31,9 +31,17 @@ func NewRouter(s StoreAPI, pool *pgxpool.Pool, registry *searchparam.Registry, b
 		}
 	})
 
+	// System-level transaction / batch Bundle, posted to the FHIR base. Registered
+	// without a trailing slash here and with one below so both /fhir/r4 and
+	// /fhir/r4/ are accepted.
+	r.Post("/fhir/r4", h.bundle)
+
 	r.Route("/fhir/r4", func(r chi.Router) {
 		// Capability statement
 		r.Get("/metadata", h.metadata)
+
+		// System-level transaction / batch Bundle (trailing-slash form)
+		r.Post("/", h.bundle)
 
 		// Per-resource-type routes
 		r.Route("/{resourceType}", func(r chi.Router) {

--- a/miscellaneous/fhir-server-go/internal/handler/store.go
+++ b/miscellaneous/fhir-server-go/internal/handler/store.go
@@ -21,4 +21,5 @@ type StoreAPI interface {
 	FetchReferences(ctx context.Context, resourceType, resourceID string, reverse bool) ([]map[string]any, error)
 	SyncSearchParameter(ctx context.Context, body map[string]any) error
 	DeleteSearchParameter(ctx context.Context, resourceID string) error
+	ExecuteBundle(ctx context.Context, bundleType, baseURL string, entries []store.BundleEntryRequest) ([]store.BundleEntryResult, error)
 }

--- a/miscellaneous/fhir-server-go/internal/index/extractor.go
+++ b/miscellaneous/fhir-server-go/internal/index/extractor.go
@@ -306,12 +306,11 @@ func indexQuantity(ctx context.Context, tx pgx.Tx, rt, rid, param string, vals [
 		}
 		sys := asString(m["system"])
 		code := asString(m["code"])
-		unit := asString(m["unit"])
 		eps := math.Abs(f) * 1e-7
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO sp_quantity (resource_id, resource_type, param_name, value_low, value_high, system, code, unit)
+			INSERT INTO sp_quantity (resource_id, resource_type, param_name, value, value_low, value_high, system, code)
 			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-			rid, rt, param, f-eps, f+eps, sys, code, unit,
+			rid, rt, param, f, f-eps, f+eps, sys, code,
 		); err != nil {
 			return err
 		}

--- a/miscellaneous/fhir-server-go/internal/index/extractor.go
+++ b/miscellaneous/fhir-server-go/internal/index/extractor.go
@@ -158,6 +158,11 @@ func insertToken(ctx context.Context, tx pgx.Tx, rt, rid, param string, v any) e
 	sys := asString(m["system"])
 	code := asString(m["code"])
 	display := asString(m["display"])
+	// Identifier and ContactPoint carry their token in "value" rather than
+	// "code"; fall back to it so identifier/telecom token searches match.
+	if code == "" {
+		code = asString(m["value"])
+	}
 	if code == "" {
 		return nil
 	}

--- a/miscellaneous/fhir-server-go/internal/store/bundle.go
+++ b/miscellaneous/fhir-server-go/internal/store/bundle.go
@@ -33,6 +33,13 @@ type BundleEntryResult struct {
 	ETag     string         // entry.response.etag, e.g. W/"1"
 	Resource map[string]any // entry.resource for the response (POST/PUT/GET payloads)
 	Outcome  map[string]any // OperationOutcome — set for batch entries that failed
+
+	// Method/ResourceType/ID describe the interaction that produced this result.
+	// They let the handler run post-commit maintenance (e.g. SearchParameter
+	// registry sync/cleanup) uniformly, including for DELETE which has no Resource.
+	Method       string
+	ResourceType string
+	ID           string
 }
 
 // BundleError is returned by ExecuteBundle when a transaction (atomic) Bundle
@@ -154,9 +161,30 @@ func (s *Store) executeTransaction(ctx context.Context, baseURL string, entries 
 	return results, nil
 }
 
-// execOpInTx runs a single planned op against an open transaction. A returned
+// execOpInTx runs a single planned op against an open transaction, stamping the
+// result with the interaction's method/type/id so the caller can run post-commit
+// maintenance (e.g. SearchParameter registry sync) uniformly. A returned
 // *BundleError aborts (and rolls back) the whole transaction.
 func (s *Store) execOpInTx(ctx context.Context, tx pgx.Tx, op bundleOp) (BundleEntryResult, *BundleError) {
+	res, berr := s.runOpInTx(ctx, tx, op)
+	if berr != nil {
+		return res, berr
+	}
+	res.Method = op.method
+	if op.skip && op.skipResType != "" {
+		res.ResourceType = op.skipResType
+		res.ID = op.skipID
+	} else {
+		res.ResourceType = op.resourceType
+		if res.ID == "" {
+			res.ID = op.id
+		}
+	}
+	return res, nil
+}
+
+// runOpInTx executes a single planned op against the open transaction.
+func (s *Store) runOpInTx(ctx context.Context, tx pgx.Tx, op bundleOp) (BundleEntryResult, *BundleError) {
 	if op.skip {
 		return BundleEntryResult{
 			Status:   op.skipStatus,

--- a/miscellaneous/fhir-server-go/internal/store/bundle.go
+++ b/miscellaneous/fhir-server-go/internal/store/bundle.go
@@ -289,8 +289,15 @@ func (s *Store) execGetInTx(ctx context.Context, tx pgx.Tx, op bundleOp) (Bundle
 		return BundleEntryResult{Status: "200 OK", Resource: res, ETag: etag(res)}, nil
 	}
 
-	// Search is served from the committed snapshot (the pool), so it does not
-	// observe not-yet-committed writes from earlier entries in this Bundle.
+	// Search is served from the committed snapshot (the pool), NOT the open
+	// transaction — so a GET search at the end of a Bundle does not observe
+	// not-yet-committed writes from earlier POST/PUT/PATCH/DELETE entries.
+	// This is a known limitation of the current Store API: search uses the
+	// pool, not a tx. Moving to a tx-aware search builder requires plumbing
+	// pgx.Tx through buildExistsForValue, count(), fetch(), and resolveIncludes
+	// — tracked as a follow-up so this PR doesn't grow into a Store refactor.
+	// GETs are still processed last (FHIR verb order) so this only affects
+	// Bundles that mix writes and reads against the same data.
 	result, err := s.Search(ctx, SearchParams{ResourceType: op.resourceType, Params: valuesToMap(op.query)})
 	if err != nil {
 		return BundleEntryResult{}, &BundleError{HTTPStatus: 500, Code: "exception", Diagnostics: err.Error()}
@@ -374,6 +381,9 @@ func (s *Store) planOps(ctx context.Context, baseURL string, entries []BundleEnt
 			if rt == "" {
 				return nil, nil, &BundleError{HTTPStatus: 400, Code: "value", EntryIndex: i, Diagnostics: "POST entry.request.url must be a resource type"}
 			}
+			if e.Resource == nil {
+				return nil, nil, &BundleError{HTTPStatus: 400, Code: "required", EntryIndex: i, Diagnostics: "POST entry.resource is required"}
+			}
 			// Conditional create (If-None-Exist): reuse an existing match if present.
 			if e.IfNoneExist != "" {
 				existingID, count, serr := s.conditionalMatch(ctx, rt, e.IfNoneExist)
@@ -411,6 +421,9 @@ func (s *Store) planOps(ctx context.Context, baseURL string, entries []BundleEnt
 			if rt == "" {
 				return nil, nil, &BundleError{HTTPStatus: 400, Code: "value", EntryIndex: i, Diagnostics: "PUT entry.request.url must include a resource type"}
 			}
+			if e.Resource == nil {
+				return nil, nil, &BundleError{HTTPStatus: 400, Code: "required", EntryIndex: i, Diagnostics: "PUT entry.resource is required"}
+			}
 			// Conditional update: url carries a query and no id.
 			if id == "" && len(query) > 0 {
 				existingID, count, serr := s.conditionalMatch(ctx, rt, query.Encode())
@@ -435,6 +448,9 @@ func (s *Store) planOps(ctx context.Context, baseURL string, entries []BundleEnt
 			}
 
 		case "PATCH", "DELETE":
+			if method == "PATCH" && e.Resource == nil {
+				return nil, nil, &BundleError{HTTPStatus: 400, Code: "required", EntryIndex: i, Diagnostics: "PATCH entry.resource is required"}
+			}
 			// Conditional delete: url carries a query and no id.
 			if id == "" && len(query) > 0 {
 				existingID, count, serr := s.conditionalMatch(ctx, rt, query.Encode())
@@ -497,13 +513,13 @@ func parseEntryURL(baseURL, raw string) (resourceType, id, versionID string, que
 	if raw == "" {
 		return "", "", "", nil, "entry.request.url is required"
 	}
-	// Strip an absolute base if present.
+	// Strip an absolute base if present. Reject absolute URLs that point at a
+	// different server — silently treating them as local paths could cause an
+	// entry to operate on the wrong resource.
 	if baseURL != "" && strings.HasPrefix(raw, baseURL) {
 		raw = strings.TrimPrefix(raw, baseURL)
-	} else if i := strings.Index(raw, "://"); i >= 0 {
-		if slash := strings.IndexByte(raw[i+3:], '/'); slash >= 0 {
-			raw = raw[i+3+slash:]
-		}
+	} else if strings.Contains(raw, "://") {
+		return "", "", "", nil, fmt.Sprintf("entry.request.url %q must be relative or under the server baseURL", raw)
 	}
 	raw = strings.TrimPrefix(raw, "/")
 

--- a/miscellaneous/fhir-server-go/internal/store/bundle.go
+++ b/miscellaneous/fhir-server-go/internal/store/bundle.go
@@ -1,0 +1,646 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// ─── Bundle request / response types ──────────────────────────────────────────
+
+// BundleEntryRequest is one parsed entry of a transaction or batch Bundle.
+type BundleEntryRequest struct {
+	FullURL     string         // entry.fullUrl (e.g. "urn:uuid:…" or an absolute URL)
+	Resource    map[string]any // entry.resource (nil for GET/DELETE)
+	Method      string         // entry.request.method — GET, POST, PUT, PATCH, DELETE
+	URL         string         // entry.request.url — "Patient", "Patient/123", "Patient?name=x"
+	IfMatch     string         // entry.request.ifMatch — ETag, e.g. W/"2"
+	IfNoneExist string         // entry.request.ifNoneExist — conditional-create query
+}
+
+// BundleEntryResult is the outcome of processing one entry. It maps to a
+// transaction-response / batch-response Bundle entry.
+type BundleEntryResult struct {
+	Status   string         // HTTP status line, e.g. "201 Created"
+	Location string         // entry.response.location (relative, e.g. "Patient/123/_history/1")
+	ETag     string         // entry.response.etag, e.g. W/"1"
+	Resource map[string]any // entry.resource for the response (POST/PUT/GET payloads)
+	Outcome  map[string]any // OperationOutcome — set for batch entries that failed
+}
+
+// BundleError is returned by ExecuteBundle when a transaction (atomic) Bundle
+// fails. It carries the HTTP status the handler should surface and a diagnostic
+// message; the whole transaction has already been rolled back.
+type BundleError struct {
+	HTTPStatus  int
+	Code        string // FHIR issue code, e.g. "processing", "not-found"
+	EntryIndex  int    // 0-based index of the offending entry, or -1
+	Diagnostics string
+}
+
+func (e *BundleError) Error() string {
+	if e.EntryIndex >= 0 {
+		return fmt.Sprintf("bundle entry %d: %s", e.EntryIndex, e.Diagnostics)
+	}
+	return e.Diagnostics
+}
+
+// bundleOp is the planned, reference-resolved form of a BundleEntryRequest,
+// ready for ordered execution.
+type bundleOp struct {
+	origIndex    int
+	method       string
+	resourceType string
+	id           string // resolved target id (PUT/PATCH/DELETE/GET-read)
+	versionID    string // for GET vread (_history/{vid})
+	body         map[string]any
+	ifMatch      int        // parsed If-Match version, or -1 for none
+	query        url.Values // GET search / conditional delete filter
+	isSearch     bool       // GET against a type (search) vs GET of an instance (read)
+	allowCreate  bool       // PUT may create when the target is missing (conditional update, 0 matches)
+
+	// conditional-create / -update that matched an existing resource: no write
+	// is performed and the entry resolves to the matched resource.
+	skip        bool
+	skipStatus  string
+	skipResType string
+	skipID      string
+}
+
+// ─── Entry point ──────────────────────────────────────────────────────────────
+
+// ExecuteBundle processes a transaction or batch Bundle.
+//
+//   - "transaction": all entries are applied atomically in a single DB
+//     transaction. urn:uuid references between entries are resolved, entries are
+//     processed in FHIR verb order (DELETE, POST, PUT/PATCH, GET), and any error
+//     rolls the whole Bundle back and returns a *BundleError.
+//   - "batch": each entry is applied independently in its own transaction; a
+//     failing entry yields an OperationOutcome in its response and does not
+//     affect the others. ExecuteBundle itself returns a nil error.
+//
+// baseURL is used to recognise references written as absolute URLs.
+func (s *Store) ExecuteBundle(ctx context.Context, bundleType, baseURL string, entries []BundleEntryRequest) ([]BundleEntryResult, error) {
+	switch bundleType {
+	case "transaction":
+		return s.executeTransaction(ctx, baseURL, entries)
+	case "batch":
+		return s.executeBatch(ctx, baseURL, entries), nil
+	default:
+		return nil, &BundleError{
+			HTTPStatus:  400,
+			Code:        "value",
+			EntryIndex:  -1,
+			Diagnostics: fmt.Sprintf("Bundle.type must be 'transaction' or 'batch', got %q", bundleType),
+		}
+	}
+}
+
+// ─── Transaction (atomic) ──────────────────────────────────────────────────────
+
+func (s *Store) executeTransaction(ctx context.Context, baseURL string, entries []BundleEntryRequest) ([]BundleEntryResult, error) {
+	// Plan: assign ids, resolve conditionals, build the reference map.
+	ops, refMap, err := s.planOps(ctx, baseURL, entries)
+	if err != nil {
+		return nil, err
+	}
+
+	// Rewrite urn:uuid / absolute-URL references to "Type/id" form across every
+	// resource body so inter-entry references point at the assigned ids.
+	for i := range ops {
+		if ops[i].body != nil {
+			rewriteReferences(ops[i].body, refMap)
+		}
+	}
+
+	// Process in FHIR verb order, preserving original order within each verb.
+	order := make([]int, len(ops))
+	for i := range order {
+		order[i] = i
+	}
+	sort.SliceStable(order, func(a, b int) bool {
+		return methodOrder(ops[order[a]].method) < methodOrder(ops[order[b]].method)
+	})
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, &BundleError{HTTPStatus: 500, Code: "exception", EntryIndex: -1, Diagnostics: err.Error()}
+	}
+	defer tx.Rollback(ctx)
+
+	results := make([]BundleEntryResult, len(ops))
+	for _, idx := range order {
+		op := ops[idx]
+		res, berr := s.execOpInTx(ctx, tx, op)
+		if berr != nil {
+			berr.EntryIndex = op.origIndex
+			return nil, berr // defer rolls the whole transaction back
+		}
+		results[op.origIndex] = res
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, &BundleError{HTTPStatus: 500, Code: "exception", EntryIndex: -1, Diagnostics: err.Error()}
+	}
+
+	slog.Info("processed transaction bundle", "entries", len(entries))
+	return results, nil
+}
+
+// execOpInTx runs a single planned op against an open transaction. A returned
+// *BundleError aborts (and rolls back) the whole transaction.
+func (s *Store) execOpInTx(ctx context.Context, tx pgx.Tx, op bundleOp) (BundleEntryResult, *BundleError) {
+	if op.skip {
+		return BundleEntryResult{
+			Status:   op.skipStatus,
+			Location: op.skipResType + "/" + op.skipID,
+		}, nil
+	}
+
+	switch op.method {
+	case "POST":
+		res, err := s.createInTx(ctx, tx, op.resourceType, op.body)
+		if err != nil {
+			return BundleEntryResult{}, storeErrToBundleErr(err)
+		}
+		id, _ := res["id"].(string)
+		return BundleEntryResult{
+			Status:   "201 Created",
+			Location: fmt.Sprintf("%s/%s/_history/%s", op.resourceType, id, metaVersionID(res)),
+			ETag:     etag(res),
+			Resource: res,
+		}, nil
+
+	case "PUT":
+		res, err := s.updateInTx(ctx, tx, op.resourceType, op.id, op.body, op.ifMatch)
+		if err != nil {
+			// A conditional update that matched zero resources creates the target;
+			// a plain PUT to a missing id is a 404 (the server does not do
+			// update-as-create), which in a transaction rolls everything back.
+			if _, ok := err.(NotFoundError); ok && op.allowCreate {
+				op.body["id"] = op.id
+				cres, cerr := s.createInTx(ctx, tx, op.resourceType, op.body)
+				if cerr != nil {
+					return BundleEntryResult{}, storeErrToBundleErr(cerr)
+				}
+				cid, _ := cres["id"].(string)
+				return BundleEntryResult{
+					Status:   "201 Created",
+					Location: fmt.Sprintf("%s/%s/_history/%s", op.resourceType, cid, metaVersionID(cres)),
+					ETag:     etag(cres),
+					Resource: cres,
+				}, nil
+			}
+			return BundleEntryResult{}, storeErrToBundleErr(err)
+		}
+		id, _ := res["id"].(string)
+		return BundleEntryResult{
+			Status:   "200 OK",
+			Location: fmt.Sprintf("%s/%s/_history/%s", op.resourceType, id, metaVersionID(res)),
+			ETag:     etag(res),
+			Resource: res,
+		}, nil
+
+	case "PATCH":
+		res, _, err := s.patchInTx(ctx, tx, op.resourceType, op.id, op.body)
+		if err != nil {
+			return BundleEntryResult{}, storeErrToBundleErr(err)
+		}
+		id, _ := res["id"].(string)
+		return BundleEntryResult{
+			Status:   "200 OK",
+			Location: fmt.Sprintf("%s/%s/_history/%s", op.resourceType, id, metaVersionID(res)),
+			ETag:     etag(res),
+			Resource: res,
+		}, nil
+
+	case "DELETE":
+		if err := s.deleteInTx(ctx, tx, op.resourceType, op.id); err != nil {
+			if _, ok := err.(NotFoundError); ok {
+				// Deleting something that does not exist is a no-op success.
+				return BundleEntryResult{Status: "204 No Content"}, nil
+			}
+			return BundleEntryResult{}, storeErrToBundleErr(err)
+		}
+		return BundleEntryResult{Status: "204 No Content"}, nil
+
+	case "GET":
+		return s.execGetInTx(ctx, tx, op)
+
+	default:
+		return BundleEntryResult{}, &BundleError{
+			HTTPStatus: 405, Code: "not-supported",
+			Diagnostics: fmt.Sprintf("unsupported Bundle request method %q", op.method),
+		}
+	}
+}
+
+func (s *Store) execGetInTx(ctx context.Context, tx pgx.Tx, op bundleOp) (BundleEntryResult, *BundleError) {
+	// Instance read (optionally a specific version) is served from the open
+	// transaction so it reflects earlier entries in the same Bundle.
+	if !op.isSearch {
+		if op.versionID != "" {
+			vid, _ := strconv.Atoi(op.versionID)
+			res, err := s.GetVersion(ctx, op.resourceType, op.id, vid)
+			if err != nil {
+				return BundleEntryResult{}, storeErrToBundleErr(err)
+			}
+			return BundleEntryResult{Status: "200 OK", Resource: res, ETag: etag(res)}, nil
+		}
+		res, err := s.readInTx(ctx, tx, op.resourceType, op.id)
+		if err != nil {
+			return BundleEntryResult{}, storeErrToBundleErr(err)
+		}
+		return BundleEntryResult{Status: "200 OK", Resource: res, ETag: etag(res)}, nil
+	}
+
+	// Search is served from the committed snapshot (the pool), so it does not
+	// observe not-yet-committed writes from earlier entries in this Bundle.
+	result, err := s.Search(ctx, SearchParams{ResourceType: op.resourceType, Params: valuesToMap(op.query)})
+	if err != nil {
+		return BundleEntryResult{}, &BundleError{HTTPStatus: 500, Code: "exception", Diagnostics: err.Error()}
+	}
+	return BundleEntryResult{Status: "200 OK", Resource: searchsetBundle(result)}, nil
+}
+
+// ─── Batch (independent entries) ───────────────────────────────────────────────
+
+func (s *Store) executeBatch(ctx context.Context, baseURL string, entries []BundleEntryRequest) []BundleEntryResult {
+	results := make([]BundleEntryResult, len(entries))
+	for i, e := range entries {
+		ops, _, err := s.planOps(ctx, baseURL, []BundleEntryRequest{e})
+		if err != nil {
+			results[i] = batchFailure(err)
+			continue
+		}
+		op := ops[0]
+		op.origIndex = 0
+
+		tx, txerr := s.pool.Begin(ctx)
+		if txerr != nil {
+			results[i] = batchFailure(&BundleError{HTTPStatus: 500, Code: "exception", Diagnostics: txerr.Error()})
+			continue
+		}
+		res, berr := s.execOpInTx(ctx, tx, op)
+		if berr != nil {
+			tx.Rollback(ctx)
+			results[i] = batchFailure(berr)
+			continue
+		}
+		if cerr := tx.Commit(ctx); cerr != nil {
+			results[i] = batchFailure(&BundleError{HTTPStatus: 500, Code: "exception", Diagnostics: cerr.Error()})
+			continue
+		}
+		results[i] = res
+	}
+	slog.Info("processed batch bundle", "entries", len(entries))
+	return results
+}
+
+func batchFailure(err error) BundleEntryResult {
+	be, ok := err.(*BundleError)
+	if !ok {
+		be = &BundleError{HTTPStatus: 500, Code: "exception", Diagnostics: err.Error()}
+	}
+	return BundleEntryResult{
+		Status:  fmt.Sprintf("%d %s", be.HTTPStatus, httpReason(be.HTTPStatus)),
+		Outcome: operationOutcomeMap("error", be.Code, be.Diagnostics),
+	}
+}
+
+// ─── Planning: id assignment, conditional resolution, reference map ────────────
+
+func (s *Store) planOps(ctx context.Context, baseURL string, entries []BundleEntryRequest) ([]bundleOp, map[string]string, error) {
+	ops := make([]bundleOp, len(entries))
+	refMap := map[string]string{}
+
+	for i, e := range entries {
+		method := strings.ToUpper(strings.TrimSpace(e.Method))
+		if method == "" {
+			return nil, nil, &BundleError{HTTPStatus: 400, Code: "required", EntryIndex: i, Diagnostics: "entry.request.method is required"}
+		}
+		rt, id, vid, query, perr := parseEntryURL(baseURL, e.URL)
+		if perr != "" {
+			return nil, nil, &BundleError{HTTPStatus: 400, Code: "value", EntryIndex: i, Diagnostics: perr}
+		}
+
+		op := bundleOp{origIndex: i, method: method, resourceType: rt, id: id, versionID: vid, body: e.Resource, ifMatch: -1}
+
+		if e.IfMatch != "" {
+			if v, ok := parseETagVersion(e.IfMatch); ok {
+				op.ifMatch = v
+			} else {
+				return nil, nil, &BundleError{HTTPStatus: 400, Code: "value", EntryIndex: i, Diagnostics: "invalid If-Match in entry.request.ifMatch"}
+			}
+		}
+
+		switch method {
+		case "POST":
+			if rt == "" {
+				return nil, nil, &BundleError{HTTPStatus: 400, Code: "value", EntryIndex: i, Diagnostics: "POST entry.request.url must be a resource type"}
+			}
+			// Conditional create (If-None-Exist): reuse an existing match if present.
+			if e.IfNoneExist != "" {
+				existingID, count, serr := s.conditionalMatch(ctx, rt, e.IfNoneExist)
+				if serr != nil {
+					return nil, nil, &BundleError{HTTPStatus: 500, Code: "exception", EntryIndex: i, Diagnostics: serr.Error()}
+				}
+				if count > 1 {
+					return nil, nil, &BundleError{HTTPStatus: 412, Code: "conflict", EntryIndex: i, Diagnostics: fmt.Sprintf("If-None-Exist matched %d resources", count)}
+				}
+				if count == 1 {
+					op.skip = true
+					op.skipStatus = "200 OK"
+					op.skipResType = rt
+					op.skipID = existingID
+					if e.FullURL != "" {
+						refMap[e.FullURL] = rt + "/" + existingID
+					}
+					ops[i] = op
+					continue
+				}
+			}
+			// Assign an id up front so other entries can reference this one.
+			newID := assignedID(e.Resource)
+			op.id = newID
+			if op.body == nil {
+				op.body = map[string]any{}
+			}
+			op.body["id"] = newID
+			op.body["resourceType"] = rt
+			if e.FullURL != "" {
+				refMap[e.FullURL] = rt + "/" + newID
+			}
+
+		case "PUT":
+			if rt == "" {
+				return nil, nil, &BundleError{HTTPStatus: 400, Code: "value", EntryIndex: i, Diagnostics: "PUT entry.request.url must include a resource type"}
+			}
+			// Conditional update: url carries a query and no id.
+			if id == "" && len(query) > 0 {
+				existingID, count, serr := s.conditionalMatch(ctx, rt, query.Encode())
+				if serr != nil {
+					return nil, nil, &BundleError{HTTPStatus: 500, Code: "exception", EntryIndex: i, Diagnostics: serr.Error()}
+				}
+				if count > 1 {
+					return nil, nil, &BundleError{HTTPStatus: 412, Code: "conflict", EntryIndex: i, Diagnostics: fmt.Sprintf("conditional update matched %d resources", count)}
+				}
+				if count == 1 {
+					op.id = existingID
+				} else {
+					op.id = assignedID(e.Resource) // create with a fresh (or body-supplied) id
+					op.allowCreate = true
+				}
+			}
+			if op.id == "" {
+				return nil, nil, &BundleError{HTTPStatus: 400, Code: "value", EntryIndex: i, Diagnostics: "PUT entry.request.url must include an id or a conditional query"}
+			}
+			if e.FullURL != "" {
+				refMap[e.FullURL] = rt + "/" + op.id
+			}
+
+		case "PATCH", "DELETE":
+			// Conditional delete: url carries a query and no id.
+			if id == "" && len(query) > 0 {
+				existingID, count, serr := s.conditionalMatch(ctx, rt, query.Encode())
+				if serr != nil {
+					return nil, nil, &BundleError{HTTPStatus: 500, Code: "exception", EntryIndex: i, Diagnostics: serr.Error()}
+				}
+				if count == 0 {
+					op.skip = true
+					op.skipStatus = "204 No Content"
+					ops[i] = op
+					continue
+				}
+				if count > 1 {
+					return nil, nil, &BundleError{HTTPStatus: 412, Code: "conflict", EntryIndex: i, Diagnostics: fmt.Sprintf("conditional %s matched %d resources", method, count)}
+				}
+				op.id = existingID
+			}
+			if op.id == "" {
+				return nil, nil, &BundleError{HTTPStatus: 400, Code: "value", EntryIndex: i, Diagnostics: method + " entry.request.url must include an id or a conditional query"}
+			}
+
+		case "GET":
+			if rt == "" {
+				return nil, nil, &BundleError{HTTPStatus: 400, Code: "value", EntryIndex: i, Diagnostics: "GET entry.request.url must include a resource type"}
+			}
+			op.isSearch = id == ""
+			op.query = query
+		}
+
+		ops[i] = op
+	}
+
+	return ops, refMap, nil
+}
+
+// conditionalMatch runs a search and returns the single matched id (if count==1),
+// the total match count, and any error.
+func (s *Store) conditionalMatch(ctx context.Context, resourceType, rawQuery string) (id string, count int, err error) {
+	q, perr := url.ParseQuery(rawQuery)
+	if perr != nil {
+		return "", 0, perr
+	}
+	result, serr := s.Search(ctx, SearchParams{ResourceType: resourceType, Params: valuesToMap(q), PageSize: 2})
+	if serr != nil {
+		return "", 0, serr
+	}
+	if result.Total == 1 && len(result.Entries) == 1 {
+		id, _ = result.Entries[0]["id"].(string)
+	}
+	return id, result.Total, nil
+}
+
+// ─── URL / reference helpers ───────────────────────────────────────────────────
+
+// parseEntryURL splits a Bundle entry.request.url (relative to the FHIR base,
+// or absolute under baseURL) into its parts. On a malformed URL it returns a
+// non-empty error string.
+func parseEntryURL(baseURL, raw string) (resourceType, id, versionID string, query url.Values, errMsg string) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", "", "", nil, "entry.request.url is required"
+	}
+	// Strip an absolute base if present.
+	if baseURL != "" && strings.HasPrefix(raw, baseURL) {
+		raw = strings.TrimPrefix(raw, baseURL)
+	} else if i := strings.Index(raw, "://"); i >= 0 {
+		if slash := strings.IndexByte(raw[i+3:], '/'); slash >= 0 {
+			raw = raw[i+3+slash:]
+		}
+	}
+	raw = strings.TrimPrefix(raw, "/")
+
+	path := raw
+	if q := strings.IndexByte(raw, '?'); q >= 0 {
+		path = raw[:q]
+		parsed, err := url.ParseQuery(raw[q+1:])
+		if err != nil {
+			return "", "", "", nil, "invalid query string in entry.request.url"
+		}
+		query = parsed
+	}
+
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	switch {
+	case len(parts) >= 4 && parts[2] == "_history":
+		// Type/id/_history/vid
+		return parts[0], parts[1], parts[3], query, ""
+	case len(parts) == 2:
+		return parts[0], parts[1], "", query, ""
+	case len(parts) == 1:
+		return parts[0], "", "", query, ""
+	default:
+		return "", "", "", nil, fmt.Sprintf("unsupported entry.request.url %q", raw)
+	}
+}
+
+// assignedID returns the resource's own id if present, otherwise a new uuid.
+func assignedID(body map[string]any) string {
+	if body != nil {
+		if id, ok := body["id"].(string); ok && id != "" {
+			return id
+		}
+	}
+	return uuid.NewString()
+}
+
+// rewriteReferences walks a resource and rewrites any {"reference": "<key>"}
+// whose value matches a key in refMap (a urn:uuid or absolute URL) to the
+// resolved "Type/id" form. It recurses through nested objects and arrays.
+func rewriteReferences(node any, refMap map[string]string) {
+	switch v := node.(type) {
+	case map[string]any:
+		if ref, ok := v["reference"].(string); ok {
+			if resolved, found := refMap[ref]; found {
+				v["reference"] = resolved
+			}
+		}
+		for _, child := range v {
+			rewriteReferences(child, refMap)
+		}
+	case []any:
+		for _, child := range v {
+			rewriteReferences(child, refMap)
+		}
+	}
+}
+
+// methodOrder gives the FHIR transaction processing order for a verb.
+func methodOrder(method string) int {
+	switch method {
+	case "DELETE":
+		return 0
+	case "POST":
+		return 1
+	case "PUT":
+		return 2
+	case "PATCH":
+		return 3
+	default: // GET, HEAD
+		return 4
+	}
+}
+
+// ─── Small shared helpers ──────────────────────────────────────────────────────
+
+func valuesToMap(v url.Values) map[string][]string {
+	m := make(map[string][]string, len(v))
+	for k, vs := range v {
+		m[k] = vs
+	}
+	return m
+}
+
+func etag(res map[string]any) string {
+	if v := metaVersionID(res); v != "" {
+		return fmt.Sprintf(`W/"%s"`, v)
+	}
+	return ""
+}
+
+// parseETagVersion parses an ETag like W/"3" into its integer version.
+func parseETagVersion(header string) (int, bool) {
+	s := strings.TrimSpace(header)
+	s = strings.TrimPrefix(s, "W/")
+	s = strings.Trim(s, `"`)
+	v, err := strconv.Atoi(s)
+	return v, err == nil
+}
+
+func operationOutcomeMap(severity, code, diagnostics string) map[string]any {
+	return map[string]any{
+		"resourceType": "OperationOutcome",
+		"issue": []any{map[string]any{
+			"severity":    severity,
+			"code":        code,
+			"diagnostics": diagnostics,
+		}},
+	}
+}
+
+// searchsetBundle wraps search results in a minimal searchset Bundle for use as
+// a GET response inside a transaction/batch response.
+func searchsetBundle(result SearchResult) map[string]any {
+	entries := make([]any, 0, len(result.Entries))
+	for _, res := range result.Entries {
+		entries = append(entries, map[string]any{
+			"resource": res,
+			"search":   map[string]any{"mode": "match"},
+		})
+	}
+	return map[string]any{
+		"resourceType": "Bundle",
+		"type":         "searchset",
+		"total":        result.Total,
+		"entry":        entries,
+	}
+}
+
+// storeErrToBundleErr maps a store CRUD error to the HTTP status a Bundle entry
+// (or a failed transaction) should report.
+func storeErrToBundleErr(err error) *BundleError {
+	switch e := err.(type) {
+	case NotFoundError:
+		return &BundleError{HTTPStatus: 404, Code: "not-found", Diagnostics: e.Error()}
+	case GoneError:
+		return &BundleError{HTTPStatus: 410, Code: "deleted", Diagnostics: e.Error()}
+	case ConflictError:
+		return &BundleError{HTTPStatus: 412, Code: "conflict", Diagnostics: e.Error()}
+	default:
+		return &BundleError{HTTPStatus: 500, Code: "exception", Diagnostics: err.Error()}
+	}
+}
+
+func httpReason(status int) string {
+	switch status {
+	case 200:
+		return "OK"
+	case 201:
+		return "Created"
+	case 204:
+		return "No Content"
+	case 400:
+		return "Bad Request"
+	case 404:
+		return "Not Found"
+	case 405:
+		return "Method Not Allowed"
+	case 410:
+		return "Gone"
+	case 412:
+		return "Precondition Failed"
+	case 422:
+		return "Unprocessable Entity"
+	default:
+		return "Internal Server Error"
+	}
+}

--- a/miscellaneous/fhir-server-go/internal/store/bundle_test.go
+++ b/miscellaneous/fhir-server-go/internal/store/bundle_test.go
@@ -20,7 +20,10 @@ func TestParseEntryURL(t *testing.T) {
 		{"search query", "Patient?name=smith", "Patient", "", "", false},
 		{"vread", "Patient/123/_history/2", "Patient", "123", "2", false},
 		{"absolute under base", base + "/Observation/abc", "Observation", "abc", "", false},
-		{"absolute other host", "http://other/Patient/9", "Patient", "9", "", false},
+		// An absolute URL pointing at a different server is rejected; we used to
+		// silently strip scheme+host, but that risked operating on the wrong
+		// resource if a bundle entry pointed at another server.
+		{"absolute other host", "http://other/Patient/9", "", "", "", true},
 		{"leading slash", "/Patient/5", "Patient", "5", "", false},
 		{"empty", "", "", "", "", true},
 	}

--- a/miscellaneous/fhir-server-go/internal/store/bundle_test.go
+++ b/miscellaneous/fhir-server-go/internal/store/bundle_test.go
@@ -1,0 +1,123 @@
+package store
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseEntryURL(t *testing.T) {
+	const base = "http://test-server/fhir/r4"
+	cases := []struct {
+		name    string
+		raw     string
+		wantRT  string
+		wantID  string
+		wantVer string
+		wantErr bool
+	}{
+		{"type only", "Patient", "Patient", "", "", false},
+		{"type and id", "Patient/123", "Patient", "123", "", false},
+		{"search query", "Patient?name=smith", "Patient", "", "", false},
+		{"vread", "Patient/123/_history/2", "Patient", "123", "2", false},
+		{"absolute under base", base + "/Observation/abc", "Observation", "abc", "", false},
+		{"absolute other host", "http://other/Patient/9", "Patient", "9", "", false},
+		{"leading slash", "/Patient/5", "Patient", "5", "", false},
+		{"empty", "", "", "", "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rt, id, ver, _, errMsg := parseEntryURL(base, c.raw)
+			if c.wantErr {
+				if errMsg == "" {
+					t.Fatalf("expected error for %q", c.raw)
+				}
+				return
+			}
+			if errMsg != "" {
+				t.Fatalf("unexpected error for %q: %s", c.raw, errMsg)
+			}
+			if rt != c.wantRT || id != c.wantID || ver != c.wantVer {
+				t.Errorf("parseEntryURL(%q) = (%q,%q,%q), want (%q,%q,%q)",
+					c.raw, rt, id, ver, c.wantRT, c.wantID, c.wantVer)
+			}
+		})
+	}
+}
+
+func TestParseEntryURL_Query(t *testing.T) {
+	_, _, _, q, errMsg := parseEntryURL("", "Patient?name=smith&gender=male")
+	if errMsg != "" {
+		t.Fatalf("unexpected error: %s", errMsg)
+	}
+	if q.Get("name") != "smith" || q.Get("gender") != "male" {
+		t.Errorf("query not parsed: %v", q)
+	}
+}
+
+func TestRewriteReferences(t *testing.T) {
+	refMap := map[string]string{
+		"urn:uuid:patient-1": "Patient/p1",
+		"urn:uuid:org-1":     "Organization/o1",
+	}
+	resource := map[string]any{
+		"resourceType": "Observation",
+		"subject":      map[string]any{"reference": "urn:uuid:patient-1"},
+		"performer": []any{
+			map[string]any{"reference": "urn:uuid:org-1"},
+			map[string]any{"reference": "Practitioner/keep-me"},
+		},
+		"note": map[string]any{
+			"author": map[string]any{"reference": "urn:uuid:patient-1"},
+		},
+	}
+
+	rewriteReferences(resource, refMap)
+
+	if got := resource["subject"].(map[string]any)["reference"]; got != "Patient/p1" {
+		t.Errorf("subject.reference = %v, want Patient/p1", got)
+	}
+	perf := resource["performer"].([]any)
+	if got := perf[0].(map[string]any)["reference"]; got != "Organization/o1" {
+		t.Errorf("performer[0].reference = %v, want Organization/o1", got)
+	}
+	if got := perf[1].(map[string]any)["reference"]; got != "Practitioner/keep-me" {
+		t.Errorf("performer[1].reference = %v, should be untouched", got)
+	}
+	if got := resource["note"].(map[string]any)["author"].(map[string]any)["reference"]; got != "Patient/p1" {
+		t.Errorf("nested note.author.reference = %v, want Patient/p1", got)
+	}
+}
+
+func TestMethodOrder(t *testing.T) {
+	// DELETE < POST < PUT < PATCH < GET
+	got := []int{
+		methodOrder("DELETE"),
+		methodOrder("POST"),
+		methodOrder("PUT"),
+		methodOrder("PATCH"),
+		methodOrder("GET"),
+	}
+	want := []int{0, 1, 2, 3, 4}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("methodOrder ordering = %v, want %v", got, want)
+	}
+}
+
+func TestParseETagVersion(t *testing.T) {
+	cases := map[string]struct {
+		want int
+		ok   bool
+	}{
+		`W/"3"`: {3, true},
+		`"5"`:   {5, true},
+		`7`:     {7, true},
+		`W/"x"`: {0, false},
+		``:      {0, false},
+	}
+	for in, exp := range cases {
+		v, ok := parseETagVersion(in)
+		if v != exp.want || ok != exp.ok {
+			t.Errorf("parseETagVersion(%q) = (%d,%v), want (%d,%v)", in, v, ok, exp.want, exp.ok)
+		}
+	}
+}

--- a/miscellaneous/fhir-server-go/internal/store/search.go
+++ b/miscellaneous/fhir-server-go/internal/store/search.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/wso2/open-healthcare-fhir-server-go/internal/searchparam"
 )
 
 // SearchParams are the parsed query parameters from the HTTP request.
@@ -38,7 +39,7 @@ func (s *Store) Search(ctx context.Context, sp SearchParams) (SearchResult, erro
 	}
 	offset := (sp.Page - 1) * sp.PageSize
 
-	b := &queryBuilder{rt: sp.ResourceType}
+	b := &queryBuilder{rt: sp.ResourceType, reg: s.registry}
 	b.writeBase()
 
 	for rawKey, values := range sp.Params {
@@ -112,6 +113,7 @@ func (s *Store) resolveIncludes(ctx context.Context, entries []map[string]any, r
 
 type queryBuilder struct {
 	rt    string
+	reg   *searchparam.Registry
 	where strings.Builder
 	args  []any
 	argN  int
@@ -187,12 +189,48 @@ func (b *queryBuilder) applySearchParam(param, modifier, value string) {
 	}
 }
 
-// buildExistsForValue builds an EXISTS subquery for a single value.
-// Without knowing the param type at query-build time, we do a best-effort
-// guess from the value format. In practice the handler layer can inject
-// the registry lookup; for now string/token cover the common cases.
+// buildExistsForValue builds an EXISTS subquery for a single value, routing to
+// the correct sp_* table by the param's declared type in the registry. When the
+// param is unknown to the registry (e.g. a custom param not yet loaded) it falls
+// back to a best-effort guess from the value format.
 func (b *queryBuilder) buildExistsForValue(param, modifier, value string) (string, bool) {
-	// Heuristic type detection from value format
+	if b.reg != nil {
+		if def, ok := b.reg.Lookup(b.rt, param); ok {
+			return b.buildTypedExists(def.ParamType, param, modifier, value)
+		}
+	}
+	return b.buildHeuristicExists(param, modifier, value)
+}
+
+// buildTypedExists routes a value match to the sp_* table for the given FHIR
+// search param type. Returns (subquery, false) for types we don't yet support
+// (composite, special) so the caller can skip the filter rather than misroute it.
+func (b *queryBuilder) buildTypedExists(paramType, param, modifier, value string) (string, bool) {
+	switch paramType {
+	case "string":
+		return b.buildStringExists(param, modifier, value), true
+	case "token":
+		return b.buildTokenExists(param, modifier, value), true
+	case "date", "dateTime", "instant", "Period":
+		return b.buildDateExists(param, value), true
+	case "number":
+		return b.buildNumberExists(param, value), true
+	case "quantity":
+		return b.buildQuantityExists(param, value), true
+	case "uri":
+		return b.buildURIExists(param, modifier, value), true
+	case "reference":
+		return b.buildReferenceExists(param, modifier, value), true
+	default:
+		// composite / special — not yet supported; skip rather than misroute.
+		return "", false
+	}
+}
+
+// buildHeuristicExists is the legacy value-format guess, used only when the
+// param type is unknown. Reference/quantity/uri params are never reachable here
+// once the registry is loaded.
+func (b *queryBuilder) buildHeuristicExists(param, modifier, value string) (string, bool) {
 	switch {
 	case looksLikeDate(value):
 		return b.buildDateExists(param, value), true
@@ -201,8 +239,8 @@ func (b *queryBuilder) buildExistsForValue(param, modifier, value string) (strin
 	case strings.Contains(value, "|"):
 		return b.buildTokenExists(param, modifier, value), true
 	default:
-		// Without registry type info, match against both sp_string and sp_token so
-		// plain-code token searches (e.g. gender=female) work alongside string params.
+		// Match against both sp_string and sp_token so plain-code token searches
+		// (e.g. gender=female) work alongside string params.
 		strQ := b.buildStringExists(param, modifier, value)
 		tokQ := b.buildTokenExists(param, modifier, value)
 		return strQ + " UNION ALL " + tokQ, true
@@ -298,6 +336,126 @@ func (b *queryBuilder) buildNumberExists(param, value string) string {
 		lowP := b.next(f - eps)
 		return fmt.Sprintf("SELECT 1 FROM sp_number s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND s.value_low <= %s AND s.value_high >= %s", rtP, pP, highP, lowP)
 	}
+}
+
+// buildReferenceExists matches a reference param against sp_reference. It accepts
+// "Type/id", a bare "id", or an absolute URL, and supports the :identifier
+// modifier (patient:identifier=system|value) and an explicit target-type
+// modifier (subject:Patient=123).
+func (b *queryBuilder) buildReferenceExists(param, modifier, value string) string {
+	rtP := b.next(b.rt)
+	pP := b.next(param)
+
+	if modifier == "identifier" {
+		system, val := "", value
+		if i := strings.Index(value, "|"); i >= 0 {
+			system, val = value[:i], value[i+1:]
+		}
+		if system != "" {
+			sP := b.next(system)
+			vP := b.next(val)
+			return fmt.Sprintf("SELECT 1 FROM sp_reference s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND s.identifier_system = %s AND s.identifier_value = %s", rtP, pP, sP, vP)
+		}
+		vP := b.next(val)
+		return fmt.Sprintf("SELECT 1 FROM sp_reference s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND s.identifier_value = %s", rtP, pP, vP)
+	}
+
+	typ, id := parseSearchReference(value)
+	if typ == "" && modifier != "" {
+		// e.g. subject:Patient=123 — the modifier names the target type.
+		typ = modifier
+	}
+	if typ != "" {
+		tP := b.next(typ)
+		iP := b.next(id)
+		return fmt.Sprintf("SELECT 1 FROM sp_reference s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND s.target_type = %s AND s.target_id = %s", rtP, pP, tP, iP)
+	}
+	iP := b.next(id)
+	return fmt.Sprintf("SELECT 1 FROM sp_reference s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND s.target_id = %s", rtP, pP, iP)
+}
+
+// buildQuantityExists matches a quantity param against sp_quantity. The value is
+// "[prefix]number|system|code"; system and code are optional. The third token is
+// matched against the coded (UCUM) unit stored in sp_quantity.code.
+func (b *queryBuilder) buildQuantityExists(param, value string) string {
+	numPart := value
+	var system, code string
+	if parts := strings.SplitN(value, "|", 3); len(parts) > 1 {
+		numPart = parts[0]
+		system = parts[1]
+		if len(parts) == 3 {
+			code = parts[2]
+		}
+	}
+	prefix, numStr := extractComparatorPrefix(numPart)
+	f, _ := strconv.ParseFloat(numStr, 64)
+	eps := math.Abs(f) * 1e-7
+	if eps == 0 {
+		eps = 1e-7
+	}
+	rtP := b.next(b.rt)
+	pP := b.next(param)
+
+	var cond string
+	switch prefix {
+	case "gt":
+		cond = fmt.Sprintf("s.value_high > %s", b.next(f))
+	case "lt":
+		cond = fmt.Sprintf("s.value_low < %s", b.next(f))
+	case "ge":
+		cond = fmt.Sprintf("s.value_high >= %s", b.next(f))
+	case "le":
+		cond = fmt.Sprintf("s.value_low <= %s", b.next(f))
+	case "ne":
+		hP := b.next(f + eps)
+		lP := b.next(f - eps)
+		cond = fmt.Sprintf("NOT (s.value_low <= %s AND s.value_high >= %s)", hP, lP)
+	default: // eq
+		hP := b.next(f + eps)
+		lP := b.next(f - eps)
+		cond = fmt.Sprintf("s.value_low <= %s AND s.value_high >= %s", hP, lP)
+	}
+
+	q := fmt.Sprintf("SELECT 1 FROM sp_quantity s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND %s", rtP, pP, cond)
+	if system != "" {
+		q += fmt.Sprintf(" AND s.system = %s", b.next(system))
+	}
+	if code != "" {
+		q += fmt.Sprintf(" AND s.code = %s", b.next(code))
+	}
+	return q
+}
+
+// buildURIExists matches a uri param against sp_uri (exact match). The :above /
+// :below hierarchy modifiers are not yet handled.
+func (b *queryBuilder) buildURIExists(param, _, value string) string {
+	rtP := b.next(b.rt)
+	pP := b.next(param)
+	vP := b.next(value)
+	return fmt.Sprintf("SELECT 1 FROM sp_uri s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND s.value = %s", rtP, pP, vP)
+}
+
+// parseSearchReference splits a reference search value into (type, id). It
+// accepts "Patient/123", a bare "123", or an absolute URL ending in Type/id,
+// and strips any "/_history/x" version suffix. Mirrors index.parseRefString.
+func parseSearchReference(value string) (resourceType, id string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", ""
+	}
+	if i := strings.Index(value, "/_history/"); i >= 0 {
+		value = value[:i]
+	}
+	if idx := strings.LastIndex(value, "/"); idx >= 0 {
+		pre := value[:idx]
+		if slashIdx := strings.LastIndex(pre, "/"); slashIdx >= 0 {
+			resourceType = pre[slashIdx+1:]
+		} else {
+			resourceType = pre
+		}
+		return resourceType, value[idx+1:]
+	}
+	return "", value
 }
 
 func (b *queryBuilder) applyLastUpdated(value string) {

--- a/miscellaneous/fhir-server-go/internal/store/search.go
+++ b/miscellaneous/fhir-server-go/internal/store/search.go
@@ -158,7 +158,22 @@ func (b *queryBuilder) applyParam(rawKey, value string) {
 
 func (b *queryBuilder) applySearchParam(param, modifier, value string) {
 	if modifier == "missing" {
-		exists := b.spExists("sp_string", param, "")
+		// :missing must look in the table the param was actually indexed into,
+		// otherwise typed params (reference, token, date, quantity, uri) are all
+		// reported as missing. Fall back to sp_string for params the registry
+		// doesn't know.
+		table := "sp_string"
+		if b.reg != nil {
+			if def, ok := b.reg.Lookup(b.rt, param); ok {
+				t := tableForType(def.ParamType)
+				if t == "" {
+					// composite / special — cannot determine presence; skip.
+					return
+				}
+				table = t
+			}
+		}
+		exists := b.spExists(table, param, "")
 		if value == "true" {
 			b.and(fmt.Sprintf("NOT EXISTS (%s)", exists))
 		} else {
@@ -222,8 +237,34 @@ func (b *queryBuilder) buildTypedExists(paramType, param, modifier, value string
 	case "reference":
 		return b.buildReferenceExists(param, modifier, value), true
 	default:
-		// composite / special — not yet supported; skip rather than misroute.
+		// composite / special — not yet supported. Skip rather than misroute,
+		// and surface it so a dropped filter isn't silently treated as a match.
+		slog.Warn("unsupported search param type; filter skipped",
+			"resourceType", b.rt, "param", param, "paramType", paramType)
 		return "", false
+	}
+}
+
+// tableForType maps a FHIR search param type to its sp_* index table. Returns ""
+// for types without a dedicated table (composite, special).
+func tableForType(paramType string) string {
+	switch paramType {
+	case "string":
+		return "sp_string"
+	case "token":
+		return "sp_token"
+	case "date", "dateTime", "instant", "Period":
+		return "sp_date"
+	case "number":
+		return "sp_number"
+	case "quantity":
+		return "sp_quantity"
+	case "uri":
+		return "sp_uri"
+	case "reference":
+		return "sp_reference"
+	default:
+		return ""
 	}
 }
 
@@ -393,26 +434,30 @@ func (b *queryBuilder) buildQuantityExists(param, value string) string {
 	if eps == 0 {
 		eps = 1e-7
 	}
+	low, high := f-eps, f+eps
 	rtP := b.next(b.rt)
 	pP := b.next(param)
 
+	// Compare the indexed range against the search range endpoints (mirrors
+	// buildDateExists) so boundary values are not matched incorrectly — e.g. an
+	// indexed 5 must not satisfy gt5.
 	var cond string
 	switch prefix {
 	case "gt":
-		cond = fmt.Sprintf("s.value_high > %s", b.next(f))
+		cond = fmt.Sprintf("s.value_low > %s", b.next(high))
 	case "lt":
-		cond = fmt.Sprintf("s.value_low < %s", b.next(f))
+		cond = fmt.Sprintf("s.value_high < %s", b.next(low))
 	case "ge":
-		cond = fmt.Sprintf("s.value_high >= %s", b.next(f))
+		cond = fmt.Sprintf("s.value_high >= %s", b.next(low))
 	case "le":
-		cond = fmt.Sprintf("s.value_low <= %s", b.next(f))
+		cond = fmt.Sprintf("s.value_low <= %s", b.next(high))
 	case "ne":
-		hP := b.next(f + eps)
-		lP := b.next(f - eps)
+		hP := b.next(high)
+		lP := b.next(low)
 		cond = fmt.Sprintf("NOT (s.value_low <= %s AND s.value_high >= %s)", hP, lP)
 	default: // eq
-		hP := b.next(f + eps)
-		lP := b.next(f - eps)
+		hP := b.next(high)
+		lP := b.next(low)
 		cond = fmt.Sprintf("s.value_low <= %s AND s.value_high >= %s", hP, lP)
 	}
 

--- a/miscellaneous/fhir-server-go/internal/store/search.go
+++ b/miscellaneous/fhir-server-go/internal/store/search.go
@@ -28,6 +28,14 @@ type SearchResult struct {
 	Included []map[string]any // _include / _revinclude results
 }
 
+// UnsupportedParamError is returned when a search request names a registry-known
+// param whose type the query builder can't translate (composite, special).
+// The HTTP layer should map this to a 400 OperationOutcome rather than execute
+// a query that silently ignores the predicate.
+type UnsupportedParamError struct{ Msg string }
+
+func (e *UnsupportedParamError) Error() string { return e.Msg }
+
 // Search executes a FHIR search against the resources + sp_* tables,
 // and resolves _include / _revinclude parameters.
 func (s *Store) Search(ctx context.Context, sp SearchParams) (SearchResult, error) {
@@ -49,6 +57,10 @@ func (s *Store) Search(ctx context.Context, sp SearchParams) (SearchResult, erro
 		for _, v := range values {
 			b.applyParam(rawKey, v)
 		}
+	}
+
+	if b.err != nil {
+		return SearchResult{}, b.err
 	}
 
 	total, err := b.count(ctx, s.pool)
@@ -117,6 +129,10 @@ type queryBuilder struct {
 	where strings.Builder
 	args  []any
 	argN  int
+	// err is set when the request can't be satisfied (e.g. a registry-known
+	// param of unsupported type like composite/special). Search() returns it
+	// as an UnsupportedParamError rather than silently widening the result set.
+	err error
 }
 
 func (b *queryBuilder) next(v any) string {
@@ -167,7 +183,11 @@ func (b *queryBuilder) applySearchParam(param, modifier, value string) {
 			if def, ok := b.reg.Lookup(b.rt, param); ok {
 				t := tableForType(def.ParamType)
 				if t == "" {
-					// composite / special — cannot determine presence; skip.
+					// composite / special — we can't tell from registry alone where
+					// this param indexes, so :missing is unanswerable. Fail closed
+					// rather than skipping the predicate (which widens the result
+					// set unexpectedly).
+					b.err = &UnsupportedParamError{Msg: fmt.Sprintf("param %q on %s has type %q which is not yet supported for :missing", param, b.rt, def.ParamType)}
 					return
 				}
 				table = t
@@ -237,9 +257,11 @@ func (b *queryBuilder) buildTypedExists(paramType, param, modifier, value string
 	case "reference":
 		return b.buildReferenceExists(param, modifier, value), true
 	default:
-		// composite / special — not yet supported. Skip rather than misroute,
-		// and surface it so a dropped filter isn't silently treated as a match.
-		slog.Warn("unsupported search param type; filter skipped",
+		// composite / special — not yet supported. Fail the request rather
+		// than silently dropping the predicate (which would broaden results
+		// and could surprise callers).
+		b.err = &UnsupportedParamError{Msg: fmt.Sprintf("param %q on %s has type %q which is not yet supported", param, b.rt, paramType)}
+		slog.Warn("unsupported search param type; failing request",
 			"resourceType", b.rt, "param", param, "paramType", paramType)
 		return "", false
 	}

--- a/miscellaneous/fhir-server-go/internal/store/store.go
+++ b/miscellaneous/fhir-server-go/internal/store/store.go
@@ -259,7 +259,7 @@ func (s *Store) patchInTx(ctx context.Context, tx pgx.Tx, resourceType, resource
 	if err := s.extractor.Index(ctx, tx, resourceType, resourceID, merged); err != nil {
 		return nil, 0, err
 	}
-	if err := saveHistory(ctx, tx, resourceType, resourceID, newVersion, "PUT", mergedRaw, now); err != nil {
+	if err := saveHistory(ctx, tx, resourceType, resourceID, newVersion, "PATCH", mergedRaw, now); err != nil {
 		return nil, 0, err
 	}
 

--- a/miscellaneous/fhir-server-go/internal/store/store.go
+++ b/miscellaneous/fhir-server-go/internal/store/store.go
@@ -33,6 +33,30 @@ func New(pool *pgxpool.Pool, registry *searchparam.Registry) *Store {
 // ─── Create ───────────────────────────────────────────────────────────────────
 
 func (s *Store) Create(ctx context.Context, resourceType string, body map[string]any) (map[string]any, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+
+	result, err := s.createInTx(ctx, tx, resourceType, body)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+
+	id, _ := result["id"].(string)
+	slog.Info("created resource", "type", resourceType, "id", id)
+	return result, nil
+}
+
+// createInTx performs a create within an existing transaction. It is the shared
+// implementation behind the public Create and behind transaction/batch Bundle
+// processing, where many writes must commit or roll back together.
+func (s *Store) createInTx(ctx context.Context, tx pgx.Tx, resourceType string, body map[string]any) (map[string]any, error) {
 	resourceID, _ := body["id"].(string)
 	if resourceID == "" {
 		resourceID = uuid.NewString()
@@ -47,12 +71,6 @@ func (s *Store) Create(ctx context.Context, resourceType string, body map[string
 	if err != nil {
 		return nil, fmt.Errorf("marshal resource: %w", err)
 	}
-
-	tx, err := s.pool.Begin(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback(ctx)
 
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO resources (fhir_id, resource_type, version_id, last_updated, is_deleted, resource_json)
@@ -70,11 +88,6 @@ func (s *Store) Create(ctx context.Context, resourceType string, body map[string
 		return nil, err
 	}
 
-	if err := tx.Commit(ctx); err != nil {
-		return nil, err
-	}
-
-	slog.Info("created resource", "type", resourceType, "id", resourceID)
 	return body, nil
 }
 
@@ -111,14 +124,30 @@ func (s *Store) Read(ctx context.Context, resourceType, resourceID string) (map[
 // any value >= 0 is compared to the current version_id and a ConflictError
 // (412) is returned if they differ.
 func (s *Store) Update(ctx context.Context, resourceType, resourceID string, body map[string]any, ifMatchVersion int) (map[string]any, error) {
-	body["id"] = resourceID
-	body["resourceType"] = resourceType
-
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer tx.Rollback(ctx)
+
+	result, err := s.updateInTx(ctx, tx, resourceType, resourceID, body, ifMatchVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+
+	slog.Info("updated resource", "type", resourceType, "id", resourceID, "version", metaVersionID(result))
+	return result, nil
+}
+
+// updateInTx performs an update within an existing transaction. Shared by the
+// public Update and by transaction/batch Bundle processing.
+func (s *Store) updateInTx(ctx context.Context, tx pgx.Tx, resourceType, resourceID string, body map[string]any, ifMatchVersion int) (map[string]any, error) {
+	body["id"] = resourceID
+	body["resourceType"] = resourceType
 
 	newVersion, currentVersion, lastUpdated, err := bumpVersion(ctx, tx, resourceType, resourceID)
 	if err != nil {
@@ -152,11 +181,6 @@ func (s *Store) Update(ctx context.Context, resourceType, resourceID string, bod
 		return nil, err
 	}
 
-	if err := tx.Commit(ctx); err != nil {
-		return nil, err
-	}
-
-	slog.Info("updated resource", "type", resourceType, "id", resourceID, "version", newVersion)
 	return body, nil
 }
 
@@ -172,6 +196,22 @@ func (s *Store) Patch(ctx context.Context, resourceType, resourceID string, patc
 	}
 	defer tx.Rollback(ctx)
 
+	merged, newVersion, err := s.patchInTx(ctx, tx, resourceType, resourceID, patch)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+
+	slog.Info("patched resource", "type", resourceType, "id", resourceID, "version", newVersion)
+	return merged, nil
+}
+
+// patchInTx applies a JSON Merge Patch within an existing transaction, taking a
+// FOR UPDATE lock on the row. Shared by the public Patch and by Bundle processing.
+func (s *Store) patchInTx(ctx context.Context, tx pgx.Tx, resourceType, resourceID string, patch map[string]any) (map[string]any, int, error) {
 	var raw []byte
 	var versionID int
 	var lastUpdated time.Time
@@ -182,17 +222,17 @@ func (s *Store) Patch(ctx context.Context, resourceType, resourceID string, patc
 		resourceID, resourceType,
 	).Scan(&raw, &versionID, &lastUpdated, &isDeleted); err != nil {
 		if isNoRows(err) {
-			return nil, NotFoundError{resourceType, resourceID}
+			return nil, 0, NotFoundError{resourceType, resourceID}
 		}
-		return nil, err
+		return nil, 0, err
 	}
 	if isDeleted {
-		return nil, GoneError{resourceType, resourceID}
+		return nil, 0, GoneError{resourceType, resourceID}
 	}
 
 	existing, err := unmarshalWithMeta(raw, versionID, lastUpdated)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	merged := mergePatch(existing, patch)
 	merged["id"] = resourceID
@@ -203,7 +243,7 @@ func (s *Store) Patch(ctx context.Context, resourceType, resourceID string, patc
 	merged = setMeta(merged, newVersion, now)
 	mergedRaw, err := json.Marshal(merged)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	if _, err := tx.Exec(ctx, `
@@ -211,23 +251,19 @@ func (s *Store) Patch(ctx context.Context, resourceType, resourceID string, patc
 		WHERE fhir_id = $4 AND resource_type = $5`,
 		newVersion, now, mergedRaw, resourceID, resourceType,
 	); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	if err := index.Delete(ctx, tx, resourceType, resourceID); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	if err := s.extractor.Index(ctx, tx, resourceType, resourceID, merged); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	if err := saveHistory(ctx, tx, resourceType, resourceID, newVersion, "PUT", mergedRaw, now); err != nil {
-		return nil, err
-	}
-	if err := tx.Commit(ctx); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
-	slog.Info("patched resource", "type", resourceType, "id", resourceID, "version", newVersion)
-	return merged, nil
+	return merged, newVersion, nil
 }
 
 // mergePatch applies a JSON Merge Patch (RFC 7396).
@@ -261,6 +297,22 @@ func (s *Store) Delete(ctx context.Context, resourceType, resourceID string) err
 	}
 	defer tx.Rollback(ctx)
 
+	if err := s.deleteInTx(ctx, tx, resourceType, resourceID); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+
+	slog.Info("deleted resource", "type", resourceType, "id", resourceID)
+	return nil
+}
+
+// deleteInTx soft-deletes a resource within an existing transaction. Shared by
+// the public Delete and by Bundle processing. Idempotent: deleting an already
+// deleted or non-existent resource returns nil.
+func (s *Store) deleteInTx(ctx context.Context, tx pgx.Tx, resourceType, resourceID string) error {
 	// Lock the row first to prevent a concurrent Update from bumping the version
 	// between our read and our soft-delete write, which would produce a UNIQUE
 	// constraint violation on resource_history(fhir_id, resource_type, version_id).
@@ -301,11 +353,6 @@ func (s *Store) Delete(ctx context.Context, resourceType, resourceID string) err
 		return err
 	}
 
-	if err := tx.Commit(ctx); err != nil {
-		return err
-	}
-
-	slog.Info("deleted resource", "type", resourceType, "id", resourceID)
 	return nil
 }
 
@@ -420,6 +467,40 @@ func saveHistory(ctx context.Context, tx pgx.Tx, resourceType, resourceID string
 		resourceID, resourceType, versionID, op, raw, ts,
 	)
 	return err
+}
+
+// metaVersionID returns the meta.versionId string of a resource, or "" if absent.
+func metaVersionID(body map[string]any) string {
+	if meta, ok := body["meta"].(map[string]any); ok {
+		if v, ok := meta["versionId"].(string); ok {
+			return v
+		}
+	}
+	return ""
+}
+
+// readInTx reads a live (non-deleted) resource within an existing transaction,
+// so a GET inside a transaction Bundle observes writes made earlier in the same
+// Bundle. Mirrors the public Read but uses the supplied tx instead of the pool.
+func (s *Store) readInTx(ctx context.Context, tx pgx.Tx, resourceType, resourceID string) (map[string]any, error) {
+	var raw []byte
+	var versionID int
+	var lastUpdated time.Time
+	var isDeleted bool
+	if err := tx.QueryRow(ctx, `
+		SELECT resource_json, version_id, last_updated, is_deleted
+		FROM resources WHERE fhir_id = $1 AND resource_type = $2`,
+		resourceID, resourceType,
+	).Scan(&raw, &versionID, &lastUpdated, &isDeleted); err != nil {
+		if isNoRows(err) {
+			return nil, NotFoundError{resourceType, resourceID}
+		}
+		return nil, err
+	}
+	if isDeleted {
+		return nil, GoneError{resourceType, resourceID}
+	}
+	return unmarshalWithMeta(raw, versionID, lastUpdated)
 }
 
 func bumpVersion(ctx context.Context, tx pgx.Tx, resourceType, resourceID string) (newVersion, currentVersion int, lastUpdated time.Time, err error) {

--- a/miscellaneous/fhir-server-go/internal/store/store_integration_test.go
+++ b/miscellaneous/fhir-server-go/internal/store/store_integration_test.go
@@ -550,6 +550,67 @@ func TestSearch_ByQuantityParam(t *testing.T) {
 	if lt.Total != 0 {
 		t.Errorf("expected 0 Encounters for length=lt100, got %d", lt.Total)
 	}
+
+	// Boundary: gt120 must NOT match the encounter whose length is exactly 120.
+	gtBoundary, err := s.Search(ctx, store.SearchParams{
+		ResourceType: "Encounter",
+		Params:       map[string][]string{"length": {"gt120"}},
+	})
+	if err != nil {
+		t.Fatalf("Search by length=gt120: %v", err)
+	}
+	if gtBoundary.Total != 0 {
+		t.Errorf("expected 0 Encounters for length=gt120 (boundary), got %d", gtBoundary.Total)
+	}
+}
+
+func TestSearch_MissingModifier(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+
+	// Observation.subject is a reference param, indexed into sp_reference — the
+	// table :missing previously failed to consult.
+	pat, _ := s.Create(ctx, "Patient", map[string]any{"resourceType": "Patient"})
+	patID := pat["id"].(string)
+
+	withSubject, _ := s.Create(ctx, "Observation", map[string]any{
+		"resourceType": "Observation",
+		"status":       "final",
+		"subject":      map[string]any{"reference": "Patient/" + patID},
+		"code":         map[string]any{"coding": []any{map[string]any{"system": "http://loinc.org", "code": "8310-5"}}},
+	})
+	withID := withSubject["id"].(string)
+
+	noSubject, _ := s.Create(ctx, "Observation", map[string]any{
+		"resourceType": "Observation",
+		"status":       "final",
+		"code":         map[string]any{"coding": []any{map[string]any{"system": "http://loinc.org", "code": "8310-5"}}},
+	})
+	noID := noSubject["id"].(string)
+
+	// subject:missing=true → only the Observation without a subject.
+	missing, err := s.Search(ctx, store.SearchParams{
+		ResourceType: "Observation",
+		Params:       map[string][]string{"subject:missing": {"true"}},
+	})
+	if err != nil {
+		t.Fatalf("Search subject:missing=true: %v", err)
+	}
+	if missing.Total != 1 || missing.Entries[0]["id"] != noID {
+		t.Errorf("subject:missing=true expected only %s, got total=%d", noID, missing.Total)
+	}
+
+	// subject:missing=false → only the Observation with a subject.
+	present, err := s.Search(ctx, store.SearchParams{
+		ResourceType: "Observation",
+		Params:       map[string][]string{"subject:missing": {"false"}},
+	})
+	if err != nil {
+		t.Fatalf("Search subject:missing=false: %v", err)
+	}
+	if present.Total != 1 || present.Entries[0]["id"] != withID {
+		t.Errorf("subject:missing=false expected only %s, got total=%d", withID, present.Total)
+	}
 }
 
 func TestSearch_DeletedResourcesExcluded(t *testing.T) {

--- a/miscellaneous/fhir-server-go/internal/store/store_integration_test.go
+++ b/miscellaneous/fhir-server-go/internal/store/store_integration_test.go
@@ -443,6 +443,115 @@ func TestSearch_ByDateParam(t *testing.T) {
 	}
 }
 
+func TestSearch_ByReferenceParam(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+
+	pat, _ := s.Create(ctx, "Patient", map[string]any{"resourceType": "Patient"})
+	patID := pat["id"].(string)
+
+	obs, _ := s.Create(ctx, "Observation", map[string]any{
+		"resourceType": "Observation",
+		"status":       "final",
+		"subject":      map[string]any{"reference": "Patient/" + patID},
+		"code": map[string]any{
+			"coding": []any{map[string]any{"system": "http://loinc.org", "code": "8310-5"}},
+		},
+	})
+	obsID := obs["id"].(string)
+
+	// An Observation for a different patient that must NOT match.
+	s.Create(ctx, "Observation", map[string]any{
+		"resourceType": "Observation",
+		"status":       "final",
+		"subject":      map[string]any{"reference": "Patient/someone-else"},
+		"code": map[string]any{
+			"coding": []any{map[string]any{"system": "http://loinc.org", "code": "8310-5"}},
+		},
+	})
+
+	// Type/id form: Observation?subject=Patient/<id>
+	result, err := s.Search(ctx, store.SearchParams{
+		ResourceType: "Observation",
+		Params:       map[string][]string{"subject": {"Patient/" + patID}},
+	})
+	if err != nil {
+		t.Fatalf("Search by subject=Patient/id: %v", err)
+	}
+	if result.Total != 1 {
+		t.Fatalf("expected exactly 1 Observation for subject=Patient/%s, got %d", patID, result.Total)
+	}
+	if result.Entries[0]["id"] != obsID {
+		t.Errorf("wrong Observation returned: got %v, want %v", result.Entries[0]["id"], obsID)
+	}
+
+	// Bare id form: Observation?subject=<id>
+	bare, err := s.Search(ctx, store.SearchParams{
+		ResourceType: "Observation",
+		Params:       map[string][]string{"subject": {patID}},
+	})
+	if err != nil {
+		t.Fatalf("Search by subject=<bare id>: %v", err)
+	}
+	if bare.Total != 1 {
+		t.Errorf("expected 1 Observation for subject=%s (bare id), got %d", patID, bare.Total)
+	}
+}
+
+func TestSearch_ByQuantityParam(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+
+	// Encounter.length is a quantity search param (Encounter.length).
+	s.Create(ctx, "Encounter", map[string]any{
+		"resourceType": "Encounter",
+		"status":       "finished",
+		"class":        map[string]any{"system": "http://terminology.hl7.org/CodeSystem/v3-ActCode", "code": "AMB"},
+		"length": map[string]any{
+			"value":  float64(120),
+			"unit":   "min",
+			"system": "http://unitsofmeasure.org",
+			"code":   "min",
+		},
+	})
+
+	// Exact value with system|code.
+	result, err := s.Search(ctx, store.SearchParams{
+		ResourceType: "Encounter",
+		Params:       map[string][]string{"length": {"120|http://unitsofmeasure.org|min"}},
+	})
+	if err != nil {
+		t.Fatalf("Search by length=120|...|min: %v", err)
+	}
+	if result.Total < 1 {
+		t.Errorf("expected ≥1 Encounter for length=120|...|min, got %d", result.Total)
+	}
+
+	// gt prefix.
+	gt, err := s.Search(ctx, store.SearchParams{
+		ResourceType: "Encounter",
+		Params:       map[string][]string{"length": {"gt100"}},
+	})
+	if err != nil {
+		t.Fatalf("Search by length=gt100: %v", err)
+	}
+	if gt.Total < 1 {
+		t.Errorf("expected ≥1 Encounter for length=gt100, got %d", gt.Total)
+	}
+
+	// Non-matching upper bound: lt100 should exclude the 120-min encounter.
+	lt, err := s.Search(ctx, store.SearchParams{
+		ResourceType: "Encounter",
+		Params:       map[string][]string{"length": {"lt100"}},
+	})
+	if err != nil {
+		t.Fatalf("Search by length=lt100: %v", err)
+	}
+	if lt.Total != 0 {
+		t.Errorf("expected 0 Encounters for length=lt100, got %d", lt.Total)
+	}
+}
+
 func TestSearch_DeletedResourcesExcluded(t *testing.T) {
 	s := newStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Consolidated replacement for the closed PRs #163 and #164, plus two follow-up fixes that were needed to make reference search actually return results end-to-end. All on `main`, no stacked branches.

This PR brings `fhir-server-go` to a functional state where:
- Transaction/batch Bundles work (so `urn:uuid:` Synthea-style bundles can be loaded as a single transaction)
- Reference search (`Encounter?patient=…`, `Observation?subject=Patient/…`, etc.) returns real results
- `CapabilityStatement` accurately advertises per-resource `searchParam` and `searchInclude`

Verified end-to-end against a Synthea dataset (114 resources/bundle): `Encounter?patient=<id>` → 9 results, `Observation?patient=<id>` → 36 total, `Condition?patient=<id>` → 8.

## Commits (chronological)

| Commit | Subject | Files | What it does |
|---|---|---|---|
| `3f0abc7` | feat: system-level transaction/batch Bundle endpoint | bundle.go (+646), router.go, handlers, extractor | Adds `POST /fhir/r4` and `POST /fhir/r4/` handlers; processes Bundles in FHIR verb order (DELETE→POST→PUT/PATCH→GET); rewrites `urn:uuid:`/absolute refs to `Type/id`; rolls back atomically on any entry failure |
| `304cd69` | fix: address PR review on transaction Bundle | bundle.go, integration tests | SearchParameter DELETEs inside a Bundle now call `DeleteSearchParameter` so registry stays consistent; logs bundle failures at handler boundary; slice-panic-proofs status checks |
| `3c155c2` | feat: route search params by registry type | search.go (+174), extractor.go, integration tests | `buildExistsForValue` now routes to `sp_reference`/`sp_token`/`sp_date`/`sp_quantity`/`sp_uri` based on the registry's declared param type instead of guessing from value format. Fixes the silent fallback to `sp_string UNION sp_token` for reference params (which was the root of `?patient=Patient/123` returning 0). |
| `4aec4e1` | fix: address search review feedback | search.go, integration tests | `:missing` looks up the param's actual table via the registry (`tableForType`) instead of always checking `sp_string`; quantity comparators compare against search-range endpoints (mirrors `buildDateExists`); skipped composite/special filters log `slog.Warn` instead of being silently dropped |
| `89d593a` | fix: index params with `where(resolve() is Type)` | fhirpath/eval.go (+59), eval_test.go | The FHIRPath evaluator's `where()` only recognised `key='val'`/`key!='val'` predicates — `resolve() is Type` fell into the "unsupported" branch and `filterWhere` returned nil. **49 standard reference params** (`patient`/`source`/`requester`/… on Account, CarePlan, Encounter, Condition, Observation, DiagnosticReport, etc.) use FHIRPath like `Encounter.subject.where(resolve() is Patient)` — so the indexer wrote zero rows into `sp_reference` for those params, and search returned 0 regardless of data. Adds a dedicated `kindWhereResolveIs` AST node + `filterResolveIs` that keeps references whose `.reference` starts with `<Type>/`. |
| `88b0315` | feat: emit `searchParam` + `searchInclude` in CapabilityStatement | handlers.go, integration test | `/metadata` previously advertised `search-type` as a supported interaction on every resource but never enumerated which params clients could use. The registry already held all 1706 base R4 params plus IG/custom ones — the builder just ignored it. Now projects `registry.ForResource(rt)` into `rest.resource.searchParam` and reference params into `rest.resource.searchInclude` (`"<Type>:<name>"`). `searchRevInclude` is intentionally deferred — it needs per-param target-type info the `Definition` struct doesn't carry. |

## Why a single PR instead of restoring #163 and #164 separately

When #164 merged first as written, reference search would still have returned 0 because the indexer's FHIRPath evaluator couldn't extract values for the `where(resolve() is X)` clauses on 49 standard params (commit `89d593a` discovery). The two fixes are tightly coupled by behaviour — typed search routing means nothing if the index is empty. Bundling them avoids landing #164 in a state where reference search appears broken to users.

The CapabilityStatement fix (`88b0315`) is independent but small and topical (also exercises the registry); folded in for review economy.

## Test plan

- [x] `go test ./...` passes (unit + handler tests, no Docker required)
- [x] `go test -tags integration -timeout 600s ./...` passes (testcontainers Postgres; integration tests including the new `TestMetadata_AdvertisesSearchParams`, `TestEvaluate_Where_ResolveIs_*`, bundle integration tests)
- [x] End-to-end smoke against a Synthea transaction bundle (`patient-01.json` from `fhir-canvas-explorer-df47329f`, 114 resources):
  - `POST /fhir/r4/` → 200, 114/114 entries `201 Created`
  - `GET /fhir/r4/Encounter?patient=<pid>` → 9 entries
  - `GET /fhir/r4/Encounter?subject=Patient/<pid>` → 9 entries (control)
  - `GET /fhir/r4/Observation?patient=<pid>` → 36 total (paged 20)
  - `GET /fhir/r4/Condition?patient=<pid>` → 8 entries
- [x] `GET /fhir/r4/metadata` per-resource entries now carry `searchParam` (e.g. Encounter: 23 entries) and `searchInclude` (Encounter: 13 entries including `Encounter:patient`)

## Image

The exact tree on this branch is published as `ghcr.io/nirmal070125/fhir-server-go:0.2.2` (linux/amd64, public). The OpenChoreo sandbox install script at https://gist.github.com/nirmal070125/cef9810702201bb79da11909ae0ea4e4 defaults to this tag.

## Out of scope

- `_sort` is currently a silent stub (`search.go:551` hardcodes `ORDER BY r.last_updated DESC`) — defect, deserves its own PR.
- `$validate` doesn't yet enforce loaded StructureDefinition profiles — biggest remaining repository gap, separate PR.
- `_tag`/`_profile`/`_security`/`_source`/`_language` not indexed — separate PR (uniform `meta.*` extractor addition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)