### PR TITLE
perf(fhir-server-go): fix search-index schema — source-keyed sp_* indexes, string prefix scans, unused GIN

### DIFF
--- a/miscellaneous/fhir-server-go/internal/db/schema.sql
+++ b/miscellaneous/fhir-server-go/internal/db/schema.sql
@@ -65,6 +65,9 @@ CREATE TABLE IF NOT EXISTS sp_string (
 
 CREATE INDEX IF NOT EXISTS idx_sp_str_lower ON sp_string (resource_type, param_name, value_lower);
 CREATE INDEX IF NOT EXISTS idx_sp_str_exact ON sp_string (resource_type, param_name, value_exact);
+-- Source-keyed index: serves the correlated EXISTS probe in multi-param searches
+-- (s.resource_id = r.fhir_id AND …) and the per-resource DELETE on re-index.
+CREATE INDEX IF NOT EXISTS idx_sp_str_source ON sp_string (resource_id, resource_type, param_name, value_lower);
 -- Uncomment for :contains support (requires pg_trgm extension):
 -- CREATE EXTENSION IF NOT EXISTS pg_trgm;
 -- CREATE INDEX idx_sp_str_trgm ON sp_string USING GIN (value_lower gin_trgm_ops);
@@ -87,6 +90,10 @@ CREATE TABLE IF NOT EXISTS sp_token (
 CREATE INDEX IF NOT EXISTS idx_sp_tok_sys_code ON sp_token (resource_type, param_name, system, code);
 CREATE INDEX IF NOT EXISTS idx_sp_tok_code     ON sp_token (resource_type, param_name, code);
 CREATE INDEX IF NOT EXISTS idx_sp_tok_system   ON sp_token (resource_type, param_name, system);
+-- Source-keyed index: without it, the correlated EXISTS probe in multi-param
+-- searches (e.g. Encounter?patient=X&type=Y) degenerates into hashing every
+-- sp_token row matching the code — per query. Also serves re-index DELETEs.
+CREATE INDEX IF NOT EXISTS idx_sp_tok_source ON sp_token (resource_id, resource_type, param_name, system, code);
 
 -- ─── Date search index ────────────────────────────────────────────────────────
 -- Param type: date / dateTime / Period / instant.
@@ -106,6 +113,7 @@ CREATE TABLE IF NOT EXISTS sp_date (
 );
 
 CREATE INDEX IF NOT EXISTS idx_sp_date_range ON sp_date (resource_type, param_name, value_low, value_high);
+CREATE INDEX IF NOT EXISTS idx_sp_date_source ON sp_date (resource_id, resource_type, param_name, value_low, value_high);
 
 -- ─── Number search index ──────────────────────────────────────────────────────
 -- Param type: number.
@@ -124,6 +132,7 @@ CREATE TABLE IF NOT EXISTS sp_number (
 );
 
 CREATE INDEX IF NOT EXISTS idx_sp_num_range ON sp_number (resource_type, param_name, value_low, value_high);
+CREATE INDEX IF NOT EXISTS idx_sp_num_source ON sp_number (resource_id, resource_type, param_name, value_low, value_high);
 
 -- ─── Quantity search index ────────────────────────────────────────────────────
 -- Param type: quantity.
@@ -146,6 +155,7 @@ CREATE TABLE IF NOT EXISTS sp_quantity (
 );
 
 CREATE INDEX IF NOT EXISTS idx_sp_qty_raw       ON sp_quantity (resource_type, param_name, value_low, value_high, system, code);
+CREATE INDEX IF NOT EXISTS idx_sp_qty_source    ON sp_quantity (resource_id, resource_type, param_name);
 CREATE INDEX IF NOT EXISTS idx_sp_qty_canonical ON sp_quantity (resource_type, param_name, canonical_value, canonical_units)
     WHERE canonical_value IS NOT NULL;
 
@@ -164,6 +174,7 @@ CREATE TABLE IF NOT EXISTS sp_uri (
 
 CREATE INDEX IF NOT EXISTS idx_sp_uri_exact  ON sp_uri (resource_type, param_name, value);
 CREATE INDEX IF NOT EXISTS idx_sp_uri_prefix ON sp_uri (resource_type, param_name, value text_pattern_ops);
+CREATE INDEX IF NOT EXISTS idx_sp_uri_source ON sp_uri (resource_id, resource_type, param_name, value);
 
 -- ─── Reference search index ───────────────────────────────────────────────────
 -- Param type: reference.
@@ -187,7 +198,12 @@ CREATE TABLE IF NOT EXISTS sp_reference (
 );
 
 CREATE INDEX IF NOT EXISTS idx_sp_ref_source ON sp_reference (resource_type, resource_id, param_name);
-CREATE INDEX IF NOT EXISTS idx_sp_ref_target ON sp_reference (target_type, target_id);
+-- Replaced by idx_sp_ref_target_full: leading on target_id makes the index
+-- usable for bare-id reference searches (patient=123, no Type/ prefix), and the
+-- extra columns let reference predicates resolve index-only. (target_id,
+-- target_type) prefix still serves every (target_type, target_id) lookup.
+DROP INDEX IF EXISTS idx_sp_ref_target;
+CREATE INDEX IF NOT EXISTS idx_sp_ref_target_full ON sp_reference (target_id, target_type, param_name, resource_type, resource_id);
 CREATE INDEX IF NOT EXISTS idx_sp_ref_ident  ON sp_reference (target_type, identifier_system, identifier_value)
     WHERE identifier_value IS NOT NULL;
 

--- a/miscellaneous/fhir-server-go/internal/db/schema.sql
+++ b/miscellaneous/fhir-server-go/internal/db/schema.sql
@@ -27,7 +27,11 @@ CREATE TABLE IF NOT EXISTS resources (
 
 CREATE INDEX IF NOT EXISTS idx_res_type_updated ON resources (resource_type, last_updated DESC);
 CREATE INDEX IF NOT EXISTS idx_res_active        ON resources (resource_type, last_updated DESC) WHERE is_deleted = FALSE;
-CREATE INDEX IF NOT EXISTS idx_res_json_gin      ON resources USING GIN (resource_json);
+-- idx_res_json_gin removed: no query uses jsonb operators on resource_json
+-- (all search goes through the sp_* tables), and a whole-document GIN index
+-- costs ~2.4x on resource inserts. Recreate it if jsonb containment queries
+-- are ever added.
+DROP INDEX IF EXISTS idx_res_json_gin;
 CREATE INDEX IF NOT EXISTS idx_res_search_text   ON resources USING GIN (search_text);
 
 -- ─── Version history ──────────────────────────────────────────────────────────
@@ -47,6 +51,10 @@ CREATE TABLE IF NOT EXISTS resource_history (
 
 CREATE INDEX IF NOT EXISTS idx_hist_resource ON resource_history (resource_type, fhir_id, version_id DESC);
 CREATE INDEX IF NOT EXISTS idx_hist_time     ON resource_history (recorded_at DESC);
+-- Type-level history (GET /{type}/_history): without this, the ORDER BY
+-- recorded_at LIMIT walk filters idx_hist_time row-by-row, degrading badly
+-- for resource types whose changes are rare or old.
+CREATE INDEX IF NOT EXISTS idx_hist_type_time ON resource_history (resource_type, recorded_at DESC);
 
 -- ─── String search index ─────────────────────────────────────────────────────
 -- Param type: string.
@@ -63,7 +71,13 @@ CREATE TABLE IF NOT EXISTS sp_string (
     FOREIGN KEY (resource_id, resource_type) REFERENCES resources (fhir_id, resource_type) ON DELETE CASCADE
 );
 
-CREATE INDEX IF NOT EXISTS idx_sp_str_lower ON sp_string (resource_type, param_name, value_lower);
+-- The default string match is `value_lower LIKE 'prefix%'`. A plain btree
+-- cannot serve LIKE prefix scans under a non-C collation (en_US.utf8), so the
+-- old idx_sp_str_lower forced a seq scan of sp_string on every name/address/…
+-- search. text_pattern_ops makes the prefix scan an index range scan (and
+-- still serves equality). Same technique idx_sp_uri_prefix already uses.
+DROP INDEX IF EXISTS idx_sp_str_lower;
+CREATE INDEX IF NOT EXISTS idx_sp_str_lower_pattern ON sp_string (resource_type, param_name, value_lower text_pattern_ops);
 CREATE INDEX IF NOT EXISTS idx_sp_str_exact ON sp_string (resource_type, param_name, value_exact);
 -- Source-keyed index: serves the correlated EXISTS probe in multi-param searches
 -- (s.resource_id = r.fhir_id AND …) and the per-resource DELETE on re-index.


### PR DESCRIPTION
## Purpose

Multi-param FHIR searches that combine a reference param with another param (e.g. `GET /Encounter?patient=X&type=Y`) were drastically slow under load: **~67 RPS at 722ms avg (50 JMeter threads)** on a 100K-resource dataset, degrading to 4.3s avg at 300 threads.

Root cause analysis with `EXPLAIN ANALYZE` on the exact SQL the query builder generates showed three classes of missing/wrong indexes in `schema.sql`. This PR is **schema-only** (no Go changes); the idempotent `db.Migrate` applies it automatically at startup, including in-place upgrade of existing databases (`CREATE INDEX IF NOT EXISTS` / `DROP INDEX IF EXISTS`).

## Issues fixed

### 1. No source-keyed indexes on sp_* tables
The query builder emits correlated `EXISTS (… s.resource_id = r.fhir_id AND s.param_name = … )` probes per search param, but every sp_* table except `sp_reference` only had value-keyed indexes (`(resource_type, param_name, value…)`). Postgres fell back to hash semi-joins that rebuild a hash of **every row matching the value predicate on every request** (e.g. all `sp_token` rows for a common encounter type). The same gap made the per-resource re-index `DELETE FROM sp_* WHERE resource_id=$1` (extractor.go) seq-scan all seven tables on every update.

**Fix:** add `idx_sp_*_source (resource_id, resource_type, param_name, …)` to all six value tables.

### 2. Reference target index unusable for bare-id values
`idx_sp_ref_target (target_type, target_id)` cannot be used when the search value is a bare id (`patient=123` without `Patient/` prefix) because no `target_type` predicate is emitted — the planner nested-looped thousands of heap probes instead (93ms vs 0.18ms per query, **500×**).

**Fix:** replace with `idx_sp_ref_target_full (target_id, target_type, param_name, resource_type, resource_id)` — leading on `target_id` serves both forms, the extra columns make reference predicates, `_has`, and `_revinclude` resolve index-only, and the `(target_id, target_type)` prefix still covers every existing `(target_type, target_id)` lookup.

### 3. String prefix searches seq-scan (collation)
The default string match is `value_lower LIKE 'prefix%'`, but a plain btree cannot serve LIKE prefix scans under a non-C collation (`en_US.utf8`) — every `Patient?name=…`/`family`/`address` search seq-scanned the whole `sp_string` table (44.7ms on 200K rows → 2.1ms, **20×**).

**Fix:** replace `idx_sp_str_lower` with a `text_pattern_ops` index — the same technique `idx_sp_uri_prefix` already uses.

### Also
- **Drop `idx_res_json_gin`**: no query uses jsonb operators on `resource_json` (all search goes through sp_* tables); the whole-document GIN index made resource inserts **2.4× slower** (20K inserts: 611ms → 254ms).
- **Add `idx_hist_type_time (resource_type, recorded_at DESC)`**: type-level `GET /{type}/_history` otherwise filters the global `idx_hist_time` walk row-by-row, degrading unboundedly for types with rare/old changes.

## Measurements

Synthetic 100K-resource dataset (40K Encounters, 2K Patients, 58K Observations) on Postgres 16, exact SQL emitted by the query builder for `Encounter?patient&type`:

| Query | before | after |
|---|---|---|
| search COUNT | 18.7 ms | 1.8 ms |
| search FETCH (`patient=Patient/id`) | 2.5 ms | 0.26 ms |
| search FETCH (`patient=id`, bare) | 93 ms | 0.18 ms |
| `Patient?name=…` COUNT | 44.7 ms | 2.1 ms |
| pgbench 50 clients, COUNT+FETCH per txn | 670 tps / 74.6 ms | 1,363 tps / 36.7 ms |
| 20K resource inserts | 611 ms | 254 ms |

## Verification
- Schema applies cleanly to a fresh database
- Re-applies idempotently (every statement guarded)
- Upgrades a populated database in place; all plans confirmed via `EXPLAIN (ANALYZE, BUFFERS)` to use the new indexes index-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)